### PR TITLE
Feature/se 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 ## Pulsar MQTT Provider
 
+Java server application that listens for MQTT traffic
+
 * [MQTT Documentation reference guide](http://mqtt.org/documentation/) Go here to check about MQTT
 * [Pulsar Documentation reference guide](https://pulsar.apache.org/) Go here to check about apache pulsar
-Java server application that listens for MQTT traffic
+
  
 ## Embedding in other projects
 
@@ -51,14 +53,15 @@ Ubuntu
 ```
 tar xvf pulsar-mqtt-provider-1.0-SNAPSHOT-bin.tar.gz
 cd pulsar-mqtt-provider-1.0-SNAPSHOT
-./pulsarMqttProvider.sh
+chmod 777 startApp.sh
+./startApp.sh
 ```
 
-Or if you are on Windows shell
+Or if you are on Windows shell, Unzip the build
 
 ```
  cd pulsar-mqtt-provider-1.0-SNAPSHOT
- .\pulsarMqttProvider.bat
+ .\startApp.bat
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
-# pulsar-mqtt-provider
- Java server application that listens for MQTT traffic
+## Pulsar MQTT Provider
+
+* [MQTT Documentation reference guide](http://mqtt.org/documentation/) Go here to check about MQTT
+* [Pulsar Documentation reference guide](https://pulsar.apache.org/) Go here to check about apache pulsar
+Java server application that listens for MQTT traffic
+ 
+## Embedding in other projects
+
+To embed pulsar-mqtt-provider in another maven project is sufficient to include a repository and declare the dependency:
+
+```
+<repositories>
+  <repository>
+    <id>quinovas</id>
+    <url>https://dependency.quinovas.com</url>
+    <releases>
+      <enabled>true</enabled>
+    </releases>
+    <snapshots>
+      <enabled>false</enabled>
+    </snapshots>
+  </repository>
+</repositories>
+```
+
+Include dependency in your project:
+
+```
+<dependency>
+      <groupId>com.echostreams</groupId>
+      <artifactId>pulsar-mqtt-provider</artifactId>
+      <version>1.0-SNAPSHOT</version>
+</dependency>
+```
+
+## Build from sources
+
+After a git clone of this repository, cd into the cloned sources and make sure you have maven installed to build this:
+
+`mvn install`.
+
+In project_source_folder/target directory will be produced the selfcontained file for the broker with all dependencies and a running script.
+
+## Download Runnable Build
+
+Download the self distribution tar from [QuiNovas](https://quinovas.com/artifact/download/quinovas/generic/pulsar-mqtt-provider-1.0-SNAPSHOT-bin.tar.gz) ,
+then untar and start the broker listening on `1883` port and enjoy!
+
+Ubuntu
+
+```
+tar xvf pulsar-mqtt-provider-1.0-SNAPSHOT-bin.tar.gz
+cd pulsar-mqtt-provider-1.0-SNAPSHOT
+./pulsarMqttProvider.sh
+```
+
+Or if you are on Windows shell
+
+```
+ cd pulsar-mqtt-provider-1.0-SNAPSHOT
+ .\pulsarMqttProvider.bat
+```
+
+---

--- a/config/moquette.conf
+++ b/config/moquette.conf
@@ -1,0 +1,22 @@
+##############################################
+#  Moquette configuration file. 
+#
+#  The synthax is equals to mosquitto.conf
+# 
+##############################################
+
+port 1883
+
+websocket_port 8080
+
+host 0.0.0.0
+
+password_file config/password_file.conf
+
+#false to accept only client connetions with credentials
+#true to accept client connection without credentails, validating only the one that provides
+allow_anonymous true
+
+#false to prohibit clients from connecting without a clientid.
+#true to allow clients to connect without a clientid. One will be generated for them.
+allow_zero_byte_client_id false

--- a/config/password_file.conf
+++ b/config/password_file.conf
@@ -1,0 +1,2 @@
+#the password is sha256(passwd)
+testuser:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
         <junit.version>4.12</junit.version>
         <io.netty.version>4.1.22.Final</io.netty.version>
+        <pulsar.client.version>2.3.0</pulsar.client.version>
     </properties>
 
     <dependencies>
@@ -174,6 +175,13 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.10</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.pulsar</groupId>
+            <artifactId>pulsar-client</artifactId>
+            <version>${pulsar.client.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.echostreams</groupId>
+    <artifactId>pulsar-mqtt-provider</artifactId>
+    <version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	
+	<name>Apache Pulsar MQTT Provider</name>
+    <description>Java server application that listens for MQTT traffic</description>
+    <url>http://mqtt.org/documentation</url>
+
+    <licenses>
+
+    </licenses>
+    
+    <developers>
+        <developer>
+            <email>shankar@seyfertsoft.in</email>
+            <name>Shankar Kumar</name>
+            <organization>QuiNovas</organization>
+            <organizationUrl>https://www.quinovas.com/</organizationUrl>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
+
+    <scm>
+        <url>https://github.com/QuiNovas/pulsar-mqtt-provider</url>
+        <connection>scm:git:git://github.com/QuiNovas/pulsar-mqtt-provider.git</connection>
+        <developerConnection>scm:git:git@github.com:QuiNovas/pulsar-mqtt-provider.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <organization>
+        <name>QuiNovas</name>
+        <url>https://www.quinovas.com/</url>
+    </organization>
+
+    <properties>
+        <java.version>1.8</java.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <logback.version>1.2.3</logback.version>
+        <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
+        <junit.version>4.12</junit.version>
+        <io.netty.version>4.1.22.Final</io.netty.version>
+    </properties>
+
+    <dependencies>
+	
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+		
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <version>${io.netty.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>${io.netty.version} </version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>${io.netty.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>${io.netty.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>${io.netty.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>${io.netty.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-mqtt</artifactId>
+            <version>${io.netty.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2-mvstore</artifactId>
+            <version>1.4.199</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>2.4.7</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>3.2.2</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jvm</artifactId>
+            <version>3.2.2</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.librato.metrics</groupId>
+            <artifactId>metrics-librato</artifactId>
+            <version>5.1.0</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.librato.metrics</groupId>
+            <artifactId>librato-java</artifactId>
+            <version>2.1.0</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.bugsnag</groupId>
+            <artifactId>bugsnag</artifactId>
+            <version>4.0</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.fusesource.mqtt-client</groupId>
+            <artifactId>mqtt-client</artifactId>
+            <version>1.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.paho</groupId>
+            <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+            <version>1.2.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-client</artifactId>
+            <version>9.2.0.M1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.199</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative</artifactId>
+            <version>2.0.10.Final</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <compilerArgument>-Xlint:all</compilerArgument>
+                    <showWarnings>true</showWarnings>
+                    <showDeprecation>true</showDeprecation>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
+                            <mainClass>com.echostreams.pulsar.mqtt.Server</mainClass>
+                        </manifest>
+                        <manifestEntries>
+                            <Class-Path>application.properties</Class-Path>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <!-- app build as zip -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>assembly</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/resources/assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,16 +7,16 @@
     <groupId>com.echostreams</groupId>
     <artifactId>pulsar-mqtt-provider</artifactId>
     <version>1.0-SNAPSHOT</version>
-	<packaging>jar</packaging>
-	
-	<name>Apache Pulsar MQTT Provider</name>
+    <packaging>jar</packaging>
+
+    <name>Apache Pulsar MQTT Provider</name>
     <description>Java server application that listens for MQTT traffic</description>
     <url>http://mqtt.org/documentation</url>
 
     <licenses>
 
     </licenses>
-    
+
     <developers>
         <developer>
             <email>shankar@seyfertsoft.in</email>
@@ -51,13 +51,13 @@
     </properties>
 
     <dependencies>
-	
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
-		
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>${io.netty.version} </version>
+            <version>${io.netty.version}</version>
             <scope>compile</scope>
         </dependency>
 
@@ -110,6 +110,14 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-mqtt</artifactId>
             <version>${io.netty.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${io.netty.version}</version>
+            <classifier>linux-x86_64</classifier>
             <scope>compile</scope>
         </dependency>
 
@@ -158,7 +166,14 @@
         <dependency>
             <groupId>com.bugsnag</groupId>
             <artifactId>bugsnag</artifactId>
-            <version>4.0</version>
+            <version>[3.0,4.0)</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.10</version>
             <scope>compile</scope>
         </dependency>
 
@@ -196,6 +211,28 @@
             <version>2.0.10.Final</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>2.6.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.9.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>3.0.0</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/echostreams/pulsar/mqtt/BrokerConstants.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/BrokerConstants.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt;
+
+import java.io.File;
+
+public final class BrokerConstants {
+
+    public static final String INTERCEPT_HANDLER_PROPERTY_NAME = "intercept.handler";
+    public static final String BROKER_INTERCEPTOR_THREAD_POOL_SIZE = "intercept.thread_pool.size";
+    public static final String PERSISTENT_STORE_PROPERTY_NAME = "persistent_store";
+    public static final String AUTOSAVE_INTERVAL_PROPERTY_NAME = "autosave_interval";
+    public static final String PASSWORD_FILE_PROPERTY_NAME = "password_file";
+    public static final String PORT_PROPERTY_NAME = "port";
+    public static final String HOST_PROPERTY_NAME = "host";
+    public static final String DEFAULT_MOQUETTE_STORE_H2_DB_FILENAME = "moquette_store.h2";
+    public static final String DEFAULT_PERSISTENT_PATH = System.getProperty("user.dir") + File.separator
+            + DEFAULT_MOQUETTE_STORE_H2_DB_FILENAME;
+    public static final String WEB_SOCKET_PORT_PROPERTY_NAME = "websocket_port";
+    public static final String WSS_PORT_PROPERTY_NAME = "secure_websocket_port";
+    public static final String WEB_SOCKET_PATH_PROPERTY_NAME = "websocket_path";
+    public static final String WEB_SOCKET_MAX_FRAME_SIZE_PROPERTY_NAME = "websocket_max_frame_size";
+
+    /**
+     * Defines the SSL implementation to use, default to "JDK".
+     * @see io.netty.handler.ssl.SslProvider#name()
+     */
+    public static final String SSL_PROVIDER = "ssl_provider";
+    public static final String SSL_PORT_PROPERTY_NAME = "ssl_port";
+    public static final String JKS_PATH_PROPERTY_NAME = "jks_path";
+
+    /** @see java.security.KeyStore#getInstance(String) for allowed types, default to "jks" */
+    public static final String KEY_STORE_TYPE = "key_store_type";
+    public static final String KEY_STORE_PASSWORD_PROPERTY_NAME = "key_store_password";
+    public static final String KEY_MANAGER_PASSWORD_PROPERTY_NAME = "key_manager_password";
+    public static final String ALLOW_ANONYMOUS_PROPERTY_NAME = "allow_anonymous";
+    public static final String REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT = "reauthorize_subscriptions_on_connect";
+    public static final String ALLOW_ZERO_BYTE_CLIENT_ID_PROPERTY_NAME = "allow_zero_byte_client_id";
+    public static final String ACL_FILE_PROPERTY_NAME = "acl_file";
+    public static final String AUTHORIZATOR_CLASS_NAME = "authorizator_class";
+    public static final String AUTHENTICATOR_CLASS_NAME = "authenticator_class";
+    public static final String DB_AUTHENTICATOR_DRIVER = "authenticator.db.driver";
+    public static final String DB_AUTHENTICATOR_URL = "authenticator.db.url";
+    public static final String DB_AUTHENTICATOR_QUERY = "authenticator.db.query";
+    public static final String DB_AUTHENTICATOR_DIGEST = "authenticator.db.digest";
+    public static final int PORT = 1883;
+    public static final int WEBSOCKET_PORT = 8080;
+    public static final String WEBSOCKET_PATH = "/mqtt";
+    public static final String DISABLED_PORT_BIND = "disabled";
+    public static final String HOST = "0.0.0.0";
+    public static final String NEED_CLIENT_AUTH = "need_client_auth";
+    public static final String NETTY_SO_BACKLOG_PROPERTY_NAME = "netty.so_backlog";
+    public static final String NETTY_SO_REUSEADDR_PROPERTY_NAME = "netty.so_reuseaddr";
+    public static final String NETTY_TCP_NODELAY_PROPERTY_NAME = "netty.tcp_nodelay";
+    public static final String NETTY_SO_KEEPALIVE_PROPERTY_NAME = "netty.so_keepalive";
+    public static final String NETTY_CHANNEL_TIMEOUT_SECONDS_PROPERTY_NAME = "netty.channel_timeout.seconds";
+    public static final String NETTY_EPOLL_PROPERTY_NAME = "netty.epoll";
+    public static final String NETTY_MAX_BYTES_PROPERTY_NAME = "netty.mqtt.message_size";
+    public static final int DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE = 8092;
+    public static final String IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME = "immediate_buffer_flush";
+    public static final String METRICS_ENABLE_PROPERTY_NAME = "use_metrics";
+    public static final String METRICS_LIBRATO_EMAIL_PROPERTY_NAME = "metrics.librato.email";
+    public static final String METRICS_LIBRATO_TOKEN_PROPERTY_NAME = "metrics.librato.token";
+    public static final String METRICS_LIBRATO_SOURCE_PROPERTY_NAME = "metrics.librato.source";
+
+    public static final String BUGSNAG_ENABLE_PROPERTY_NAME = "use_bugsnag";
+    public static final String BUGSNAG_TOKEN_PROPERTY_NAME = "bugsnag.token";
+
+    public static final String STORAGE_CLASS_NAME = "storage_class";
+
+    private BrokerConstants() {
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/BrokerConstants.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/BrokerConstants.java
@@ -37,13 +37,16 @@ public final class BrokerConstants {
 
     /**
      * Defines the SSL implementation to use, default to "JDK".
+     *
      * @see io.netty.handler.ssl.SslProvider#name()
      */
     public static final String SSL_PROVIDER = "ssl_provider";
     public static final String SSL_PORT_PROPERTY_NAME = "ssl_port";
     public static final String JKS_PATH_PROPERTY_NAME = "jks_path";
 
-    /** @see java.security.KeyStore#getInstance(String) for allowed types, default to "jks" */
+    /**
+     * @see java.security.KeyStore#getInstance(String) for allowed types, default to "jks"
+     */
     public static final String KEY_STORE_TYPE = "key_store_type";
     public static final String KEY_STORE_PASSWORD_PROPERTY_NAME = "key_store_password";
     public static final String KEY_MANAGER_PASSWORD_PROPERTY_NAME = "key_manager_password";
@@ -81,6 +84,19 @@ public final class BrokerConstants {
     public static final String BUGSNAG_TOKEN_PROPERTY_NAME = "bugsnag.token";
 
     public static final String STORAGE_CLASS_NAME = "storage_class";
+
+    /**
+     * Pulsar Related Config
+     */
+
+    public static final String PERSISTENT_PROPERTY_NAME = "persistent";
+    public static final String TENANT_PROPERTY_NAME = "tenant";
+    public static final String NAMESPACE_PROPERTY_NAME = "namespace";
+    public static final String PERSISTENT_NAME = "persistent";
+    public static final String TENANT_NAME = "default-tenant";
+    public static final String NAMESPACE_NAME = "default-namespace";
+
+    public static final String PULSAR_TOPIC_NAME_PREFIX = "pulsar_topic_name_prefix";
 
     private BrokerConstants() {
     }

--- a/src/main/java/com/echostreams/pulsar/mqtt/BrokerConstants.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/BrokerConstants.java
@@ -99,8 +99,8 @@ public final class BrokerConstants {
     public static final String SINGLE_FORWARD_SLASH = "/";
 
     public static String PERSISTENT_NAME = "persistent";
-    public static String TENANT_NAME = "default-tenant";
-    public static String NAMESPACE_NAME = "default-namespace";
+    public static String TENANT_NAME = "public";
+    public static String NAMESPACE_NAME = "default";
     public static String NON_PERSISTENT_NAME = "non-persistent";
     public static String PULSAR_TOPIC_NAME_PREFIX = PERSISTENT_NAME + DOUBLE_FORWARD_SLASH + TENANT_NAME + SINGLE_FORWARD_SLASH + NAMESPACE_NAME;
     public static String TOPIC_PROCESSING_IDENTIFIER = null;

--- a/src/main/java/com/echostreams/pulsar/mqtt/BrokerConstants.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/BrokerConstants.java
@@ -89,14 +89,22 @@ public final class BrokerConstants {
      * Pulsar Related Config
      */
 
-    public static final String PERSISTENT_PROPERTY_NAME = "persistent";
-    public static final String TENANT_PROPERTY_NAME = "tenant";
-    public static final String NAMESPACE_PROPERTY_NAME = "namespace";
-    public static final String PERSISTENT_NAME = "persistent";
-    public static final String TENANT_NAME = "default-tenant";
-    public static final String NAMESPACE_NAME = "default-namespace";
+    public static final String PULSAR_SERVICE_URL_PROPERTY_NAME = "pulsar_service_url";
+    public static final String MESSAGE_STORAGE_TYPE_PROPERTY_NAME = "message_storage_type";
+    public static final String TENANT_PROPERTY_NAME = "tenant_name";
+    public static final String NAMESPACE_PROPERTY_NAME = "namespace_name";
+    public static final String TOPIC_PROCESSING_IDENTIFIER_PROPERTY_NAME = "topic_processing_identifier";
 
-    public static final String PULSAR_TOPIC_NAME_PREFIX = "pulsar_topic_name_prefix";
+    public static final String DOUBLE_FORWARD_SLASH = "://";
+    public static final String SINGLE_FORWARD_SLASH = "/";
+
+    public static String PERSISTENT_NAME = "persistent";
+    public static String TENANT_NAME = "default-tenant";
+    public static String NAMESPACE_NAME = "default-namespace";
+    public static String NON_PERSISTENT_NAME = "non-persistent";
+    public static String PULSAR_TOPIC_NAME_PREFIX = PERSISTENT_NAME + DOUBLE_FORWARD_SLASH + TENANT_NAME + SINGLE_FORWARD_SLASH + NAMESPACE_NAME;
+    public static String TOPIC_PROCESSING_IDENTIFIER = null;
+    public static String PULSAR_SERVICE_URL = "pulsar://localhost:6650";
 
     private BrokerConstants() {
     }

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/Authorizator.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/Authorizator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import com.echostreams.pulsar.mqtt.broker.security.IAuthorizatorPolicy;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
+import io.netty.handler.codec.mqtt.MqttTopicSubscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.echostreams.pulsar.mqtt.broker.Utils.messageId;
+import static io.netty.handler.codec.mqtt.MqttQoS.FAILURE;
+
+final class Authorizator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Authorizator.class);
+
+    private final IAuthorizatorPolicy policy;
+
+    Authorizator(IAuthorizatorPolicy policy) {
+        this.policy = policy;
+    }
+
+    /**
+     * @param clientID
+     *            the clientID
+     * @param username
+     *            the username
+     * @param msg
+     *            the subscribe message to verify
+     * @return the list of verified topics for the given subscribe message.
+     */
+    List<MqttTopicSubscription> verifyTopicsReadAccess(String clientID, String username, MqttSubscribeMessage msg) {
+        List<MqttTopicSubscription> ackTopics = new ArrayList<>();
+
+        final int messageId = messageId(msg);
+        for (MqttTopicSubscription req : msg.payload().topicSubscriptions()) {
+            Topic topic = new Topic(req.topicName());
+            if (!policy.canRead(topic, username, clientID)) {
+                // send SUBACK with 0x80, the user hasn't credentials to read the topic
+                LOG.warn("Client does not have read permissions on the topic CId={}, username: {}, messageId: {}, " +
+                         "topic: {}", clientID, username, messageId, topic);
+                ackTopics.add(new MqttTopicSubscription(topic.toString(), FAILURE));
+            } else {
+                MqttQoS qos;
+                if (topic.isValid()) {
+                    LOG.debug("Client will be subscribed to the topic CId={}, username: {}, messageId: {}, topic: {}",
+                              clientID, username, messageId, topic);
+                    qos = req.qualityOfService();
+                } else {
+                    LOG.warn("Topic filter is not valid CId={}, username: {}, messageId: {}, topic: {}", clientID,
+                             username, messageId, topic);
+                    qos = FAILURE;
+                }
+                ackTopics.add(new MqttTopicSubscription(topic.toString(), qos));
+            }
+        }
+        return ackTopics;
+    }
+
+    /**
+     * Ask the authorization policy if the topic can be used in a publish.
+     *
+     * @param topic
+     *            the topic to write to.
+     * @param user
+     *            the user
+     * @param client
+     *            the client
+     * @return true if the user from client can publish data on topic.
+     */
+    boolean canWrite(Topic topic, String user, String client) {
+        return policy.canWrite(topic, user, client);
+    }
+
+    boolean canRead(Topic topic, String user, String client) {
+        return policy.canRead(topic, user, client);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/Authorizator.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/Authorizator.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.echostreams.pulsar.mqtt.broker.Utils.messageId;
+import static com.echostreams.pulsar.mqtt.broker.utils.Utils.messageId;
 import static io.netty.handler.codec.mqtt.MqttQoS.FAILURE;
 
 final class Authorizator {

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/AutoFlushHandler.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/AutoFlushHandler.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2012-2016 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.concurrent.EventExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Auto-flush data on channel after a read timeout. It's inspired by IdleStateHandler but it's
+ * specialized version, just flushing data after no read is done on the channel after a period. It's
+ * used to avoid aggressively flushing from the ProtocolProcessor.
+ */
+public class AutoFlushHandler extends ChannelDuplexHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AutoFlushHandler.class);
+    private static final long MIN_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
+
+    private final long writerIdleTimeNanos;
+    volatile ScheduledFuture<?> writerIdleTimeout;
+    volatile long lastWriteTime;
+    // private boolean firstWriterIdleEvent = true;
+
+    private volatile int state; // 0 - none, 1 - initialized, 2 - destroyed
+
+    public AutoFlushHandler(long writerIdleTime, TimeUnit unit) {
+        if (unit == null) {
+            throw new NullPointerException("unit");
+        }
+        writerIdleTimeNanos = Math.max(unit.toNanos(writerIdleTime), MIN_TIMEOUT_NANOS);
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        if (ctx.channel().isActive() && ctx.channel().isRegistered()) {
+            // channelActive() event has been fired already, which means this.channelActive() will
+            // not be invoked. We have to initialize here instead.
+            initialize(ctx);
+        } else {
+            // channelActive() event has not been fired yet. this.channelActive() will be invoked
+            // and initialization will occur there.
+        }
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) {
+        destroy();
+    }
+
+    @Override
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        // Initialize early if channel is active already.
+//        if (ctx.channel().isActive()) {
+//            initialize(ctx);
+//        }
+        super.channelRegistered(ctx);
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        // This method will be invoked only if this handler was added
+        // before channelActive() event is fired. If a user adds this handler
+        // after the channelActive() event, initialize() will be called by beforeAdd().
+//        initialize(ctx);
+        super.channelActive(ctx);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        destroy();
+        super.channelInactive(ctx);
+    }
+
+    private void initialize(ChannelHandlerContext ctx) {
+        // Avoid the case where destroy() is called before scheduling timeouts.
+        // See: https://github.com/netty/netty/issues/143
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Initializing autoflush handler on channel {} Cid: {}", ctx.channel(),
+                      NettyUtils.clientID(ctx.channel()));
+        }
+        switch (state) {
+            case 1:
+            case 2:
+                return;
+        }
+
+        state = 1;
+
+        EventExecutor loop = ctx.executor();
+
+        lastWriteTime = System.nanoTime();
+        writerIdleTimeout = loop.schedule(new WriterIdleTimeoutTask(ctx), writerIdleTimeNanos, TimeUnit.NANOSECONDS);
+    }
+
+    private void destroy() {
+        state = 2;
+
+        if (writerIdleTimeout != null) {
+            writerIdleTimeout.cancel(false);
+            writerIdleTimeout = null;
+        }
+    }
+
+    /**
+     * Is called when the write timeout expire.
+     *
+     * @param ctx the channel context.
+     */
+    private void channelIdle(ChannelHandlerContext ctx) {
+        // ctx.fireUserEventTriggered(evt);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Flushing idle Netty channel {} Cid: {}", ctx.channel(), NettyUtils.clientID(ctx.channel()));
+        }
+        ctx.channel().flush();
+    }
+
+    private final class WriterIdleTimeoutTask implements Runnable {
+
+        private final ChannelHandlerContext ctx;
+
+        WriterIdleTimeoutTask(ChannelHandlerContext ctx) {
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void run() {
+            if (!ctx.channel().isOpen()) {
+                return;
+            }
+
+            // long lastWriteTime = IdleStateHandler.this.lastWriteTime;
+            // long lastWriteTime = lastWriteTime;
+            long nextDelay = writerIdleTimeNanos - (System.nanoTime() - lastWriteTime);
+            if (nextDelay <= 0) {
+                // Writer is idle - set a new timeout and notify the callback.
+                writerIdleTimeout = ctx.executor().schedule(this, writerIdleTimeNanos, TimeUnit.NANOSECONDS);
+                try {
+                    /*
+                     * IdleStateEvent event; if (firstWriterIdleEvent) { firstWriterIdleEvent =
+                     * false; event = IdleStateEvent.FIRST_WRITER_IDLE_STATE_EVENT; } else { event =
+                     * IdleStateEvent.WRITER_IDLE_STATE_EVENT; }
+                     */
+                    channelIdle(ctx/* , event */);
+                } catch (Throwable t) {
+                    ctx.fireExceptionCaught(t);
+                }
+            } else {
+                // Write occurred before the timeout - set a new timeout with shorter delay.
+                writerIdleTimeout = ctx.executor().schedule(this, nextDelay, TimeUnit.NANOSECONDS);
+            }
+        }
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/AutoFlushHandler.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/AutoFlushHandler.java
@@ -16,6 +16,7 @@
 
 package com.echostreams.pulsar.mqtt.broker;
 
+import com.echostreams.pulsar.mqtt.broker.utils.NettyUtils;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.EventExecutor;

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/BrokerConfiguration.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/BrokerConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+
+class BrokerConfiguration {
+
+    private final boolean allowAnonymous;
+    private final boolean allowZeroByteClientId;
+    private final boolean reauthorizeSubscriptionsOnConnect;
+    private final boolean immediateBufferFlush;
+
+    BrokerConfiguration(IConfig props) {
+        allowAnonymous = props.boolProp(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, true);
+        allowZeroByteClientId = props.boolProp(BrokerConstants.ALLOW_ZERO_BYTE_CLIENT_ID_PROPERTY_NAME, false);
+        reauthorizeSubscriptionsOnConnect = props.boolProp(BrokerConstants.REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT, false);
+        immediateBufferFlush = props.boolProp(BrokerConstants.IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME, false);
+    }
+
+    public BrokerConfiguration(boolean allowAnonymous, boolean allowZeroByteClientId,
+                               boolean reauthorizeSubscriptionsOnConnect, boolean immediateBufferFlush) {
+        this.allowAnonymous = allowAnonymous;
+        this.allowZeroByteClientId = allowZeroByteClientId;
+        this.reauthorizeSubscriptionsOnConnect = reauthorizeSubscriptionsOnConnect;
+        this.immediateBufferFlush = immediateBufferFlush;
+    }
+
+    public boolean isAllowAnonymous() {
+        return allowAnonymous;
+    }
+
+    public boolean isAllowZeroByteClientId() {
+        return allowZeroByteClientId;
+    }
+
+    public boolean isReauthorizeSubscriptionsOnConnect() {
+        return reauthorizeSubscriptionsOnConnect;
+    }
+
+    public boolean isImmediateBufferFlush() {
+        return immediateBufferFlush;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/BugSnagErrorsHandler.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/BugSnagErrorsHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.bugsnag.Bugsnag;
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+@Sharable
+public class BugSnagErrorsHandler extends ChannelInboundHandlerAdapter {
+
+    private Bugsnag bugsnag;
+
+    public void init(IConfig props) {
+        final String token = props.getProperty(BrokerConstants.BUGSNAG_TOKEN_PROPERTY_NAME);
+        this.bugsnag = new Bugsnag(token);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        bugsnag.notify(cause);
+        ctx.fireExceptionCaught(cause);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/ClientDescriptor.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/ClientDescriptor.java
@@ -1,0 +1,52 @@
+package com.echostreams.pulsar.mqtt.broker;
+
+import java.util.Objects;
+
+public class ClientDescriptor {
+
+    private final String clientID;
+    private final String address;
+    private final int port;
+
+    ClientDescriptor(String clientID, String address, int port) {
+        this.clientID = clientID;
+        this.address = address;
+        this.port = port;
+    }
+
+    public String getClientID() {
+        return clientID;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClientDescriptor that = (ClientDescriptor) o;
+        return port == that.port &&
+            Objects.equals(clientID, that.clientID) &&
+            Objects.equals(address, that.address);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clientID, address, port);
+    }
+
+    @Override
+    public String toString() {
+        return "ClientDescriptor{" +
+            "clientID='" + clientID + '\'' +
+            ", address='" + address + '\'' +
+            ", port=" + port +
+            '}';
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/DebugUtils.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/DebugUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker;
+
+import io.netty.buffer.ByteBuf;
+
+import java.nio.charset.StandardCharsets;
+
+public final class DebugUtils {
+
+    public static String payload2Str(ByteBuf content) {
+        final ByteBuf copy = content.copy();
+        final byte[] bytesContent;
+        if (copy.isDirect()) {
+            final int size = copy.readableBytes();
+            bytesContent = new byte[size];
+            copy.readBytes(bytesContent);
+        } else {
+            bytesContent = copy.array();
+        }
+        return new String(bytesContent, StandardCharsets.UTF_8);
+    }
+
+    private DebugUtils() {
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/DefaultMoquetteSslContextCreator.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/DefaultMoquetteSslContextCreator.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.GeneralSecurityException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Objects;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Moquette integration implementation to load SSL certificate from local filesystem path configured in
+ * config file.
+ */
+class DefaultMoquetteSslContextCreator implements ISslContextCreator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultMoquetteSslContextCreator.class);
+
+    private final IConfig props;
+
+    DefaultMoquetteSslContextCreator(IConfig props) {
+        this.props = Objects.requireNonNull(props);
+    }
+
+    @Override
+    public SslContext initSSLContext() {
+        LOG.info("Checking SSL configuration properties...");
+
+        final String keyPassword = props.getProperty(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME);
+        if (keyPassword == null || keyPassword.isEmpty()) {
+            LOG.warn("The key manager password is null or empty. The SSL context won't be initialized.");
+            return null;
+        }
+
+        try {
+            SslProvider sslProvider = getSSLProvider();
+            KeyStore ks = loadKeyStore();
+            SslContextBuilder contextBuilder;
+            switch (sslProvider) {
+            case JDK:
+                contextBuilder = builderWithJdkProvider(ks, keyPassword);
+                break;
+            case OPENSSL:
+            case OPENSSL_REFCNT:
+                contextBuilder = builderWithOpenSSLProvider(ks, keyPassword);
+                break;
+            default:
+                LOG.error("unsupported SSL provider {}", sslProvider);
+                return null;
+            }
+            // if client authentification is enabled a trustmanager needs to be added to the ServerContext
+            String sNeedsClientAuth = props.getProperty(BrokerConstants.NEED_CLIENT_AUTH, "false");
+            if (Boolean.valueOf(sNeedsClientAuth)) {
+                addClientAuthentication(ks, contextBuilder);
+            }
+            contextBuilder.sslProvider(sslProvider);
+            SslContext sslContext = contextBuilder.build();
+            LOG.info("The SSL context has been initialized successfully.");
+            return sslContext;
+        } catch (GeneralSecurityException | IOException ex) {
+            LOG.error("Unable to initialize SSL context.", ex);
+            return null;
+        }
+    }
+
+    private KeyStore loadKeyStore() throws IOException, GeneralSecurityException {
+        final String jksPath = props.getProperty(BrokerConstants.JKS_PATH_PROPERTY_NAME);
+        LOG.info("Initializing SSL context. KeystorePath = {}.", jksPath);
+        if (jksPath == null || jksPath.isEmpty()) {
+            LOG.warn("The keystore path is null or empty. The SSL context won't be initialized.");
+            return null;
+        }
+        final String keyStorePassword = props.getProperty(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME);
+        if (keyStorePassword == null || keyStorePassword.isEmpty()) {
+            LOG.warn("The keystore password is null or empty. The SSL context won't be initialized.");
+            return null;
+        }
+        String ksType = props.getProperty(BrokerConstants.KEY_STORE_TYPE, "jks");
+        final KeyStore keyStore = KeyStore.getInstance(ksType);
+        LOG.info("Loading keystore. KeystorePath = {}.", jksPath);
+        try (InputStream jksInputStream = jksDatastore(jksPath)) {
+            keyStore.load(jksInputStream, keyStorePassword.toCharArray());
+        }
+        return keyStore;
+    }
+
+    private static SslContextBuilder builderWithJdkProvider(KeyStore ks, String keyPassword)
+            throws GeneralSecurityException {
+        LOG.info("Initializing key manager...");
+        final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, keyPassword.toCharArray());
+        LOG.info("Initializing SSL context...");
+        return SslContextBuilder.forServer(kmf);
+    }
+
+    /**
+     * The OpenSSL provider does not support the {@link KeyManagerFactory}, so we have to lookup the integration
+     * certificate and key in order to provide it to OpenSSL.
+     * <p>
+     * TODO: SNI is currently not supported, we use only the first found private key.
+     */
+    private static SslContextBuilder builderWithOpenSSLProvider(KeyStore ks, String keyPassword)
+            throws GeneralSecurityException {
+        for (String alias : Collections.list(ks.aliases())) {
+            if (ks.entryInstanceOf(alias, KeyStore.PrivateKeyEntry.class)) {
+                PrivateKey key = (PrivateKey) ks.getKey(alias, keyPassword.toCharArray());
+                Certificate[] chain = ks.getCertificateChain(alias);
+                X509Certificate[] certChain = new X509Certificate[chain.length];
+                System.arraycopy(chain, 0, certChain, 0, chain.length);
+                return SslContextBuilder.forServer(key, certChain);
+            }
+        }
+        throw new KeyManagementException("the SSL key-store does not contain a private key");
+    }
+
+    private static void addClientAuthentication(KeyStore ks, SslContextBuilder contextBuilder)
+            throws NoSuchAlgorithmException, KeyStoreException {
+        LOG.warn("Client authentication is enabled. The keystore will be used as a truststore.");
+        // use keystore as truststore, as integration needs to trust certificates signed by the integration certificates
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(ks);
+        contextBuilder.clientAuth(ClientAuth.REQUIRE);
+        contextBuilder.trustManager(tmf);
+    }
+
+    private SslProvider getSSLProvider() {
+        String providerName = props.getProperty(BrokerConstants.SSL_PROVIDER, SslProvider.JDK.name());
+        try {
+            return SslProvider.valueOf(providerName);
+        } catch (IllegalArgumentException e) {
+            LOG.warn("unknown SSL Provider {}, falling back on JDK provider", providerName);
+            return SslProvider.JDK;
+        }
+    }
+
+    private InputStream jksDatastore(String jksPath) throws FileNotFoundException {
+        URL jksUrl = getClass().getClassLoader().getResource(jksPath);
+        if (jksUrl != null) {
+            LOG.info("Starting with jks at {}, jks normal {}", jksUrl.toExternalForm(), jksUrl);
+            return getClass().getClassLoader().getResourceAsStream(jksPath);
+        }
+        LOG.warn("No keystore has been found in the bundled resources. Scanning filesystem...");
+        File jksFile = new File(jksPath);
+        if (jksFile.exists()) {
+            LOG.info("Loading external keystore. Url = {}.", jksFile.getAbsolutePath());
+            return new FileInputStream(jksFile);
+        }
+        throw new FileNotFoundException("The keystore file does not exist. Url = " + jksFile.getAbsolutePath());
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/IQueueRepository.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/IQueueRepository.java
@@ -1,0 +1,8 @@
+package com.echostreams.pulsar.mqtt.broker;
+
+import java.util.Queue;
+
+public interface IQueueRepository {
+
+    Queue<SessionRegistry.EnqueuedMessage> createQueue(String cli, boolean clean);
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/IRetainedRepository.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/IRetainedRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+
+import java.util.List;
+
+public interface IRetainedRepository {
+
+    void cleanRetained(Topic topic);
+
+    void retain(Topic topic, MqttPublishMessage msg);
+
+    boolean isEmpty();
+
+    List<RetainedMessage> retainedOnTopic(String topic);
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/ISslContextCreator.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/ISslContextCreator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker;
+
+import io.netty.handler.ssl.SslContext;
+
+/**
+ * SSL certificate loader used to open SSL connections (websocket and MQTT-S).
+ */
+public interface ISslContextCreator {
+
+    SslContext initSSLContext();
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/ISubscriptionsRepository.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/ISubscriptionsRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+
+import java.util.List;
+
+public interface ISubscriptionsRepository {
+
+    List<Subscription> listAllSubscriptions();
+
+    void addNewSubscription(Subscription subscription);
+
+    void removeSubscription(String topic, String clientID);
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/InflightResender.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/InflightResender.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2012-2016 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.concurrent.EventExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Resend inflight not ack'ed publish packets (QoS1 PUB and QoS2 PUB/PUBREL). It's inspired by IdleStateHandler but it's
+ * specialized version, just invoking Session's resendInflightNotAcked by the channel after a period.
+ */
+public class InflightResender extends ChannelDuplexHandler {
+
+    /**
+     * Placeholder event to resend not-acked publish messages in the in flight window.
+     * */
+    public static class ResendNotAckedPublishes {
+    }
+
+    private final class WriterIdleTimeoutTask implements Runnable {
+
+        private final ChannelHandlerContext ctx;
+
+        WriterIdleTimeoutTask(ChannelHandlerContext ctx) {
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void run() {
+            if (!ctx.channel().isOpen()) {
+                return;
+            }
+            long nextDelay = resenderTimeNanos - (System.nanoTime() - lastExecutionTime);
+            if (nextDelay <= 0) {
+                // Writer is idle - set a new timeout and notify the callback.
+                resenderTimeout = ctx.executor().schedule(this, resenderTimeNanos, TimeUnit.NANOSECONDS);
+                try {
+                    resendNotAcked(ctx/* , event */);
+                } catch (Throwable t) {
+                    ctx.fireExceptionCaught(t);
+                }
+            } else {
+                // Write occurred before the timeout - set a new timeout with shorter delay.
+                resenderTimeout = ctx.executor().schedule(this, nextDelay, TimeUnit.NANOSECONDS);
+            }
+        }
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(InflightResender.class);
+    private static final long MIN_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
+
+    private final long resenderTimeNanos;
+    volatile ScheduledFuture<?> resenderTimeout;
+    volatile long lastExecutionTime;
+
+    private volatile int state; // 0 - none, 1 - initialized, 2 - destroyed
+
+    public InflightResender(long writerIdleTime, TimeUnit unit) {
+        if (unit == null) {
+            throw new NullPointerException("unit");
+        }
+        resenderTimeNanos = Math.max(unit.toNanos(writerIdleTime), MIN_TIMEOUT_NANOS);
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        if (ctx.channel().isActive() && ctx.channel().isRegistered()) {
+            // channelActive() event has been fired already, which means this.channelActive() will
+            // not be invoked. We have to initialize here instead.
+            initialize(ctx);
+        } else {
+            // channelActive() event has not been fired yet. this.channelActive() will be invoked
+            // and initialization will occur there.
+        }
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        destroy();
+    }
+
+    @Override
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        // Initialize early if channel is active already.
+        if (ctx.channel().isActive()) {
+            initialize(ctx);
+        }
+        super.channelRegistered(ctx);
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        // This method will be invoked only if this handler was added
+        // before channelActive() event is fired. If a user adds this handler
+        // after the channelActive() event, initialize() will be called by beforeAdd().
+        initialize(ctx);
+        super.channelActive(ctx);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        destroy();
+        super.channelInactive(ctx);
+    }
+
+    private void initialize(ChannelHandlerContext ctx) {
+        // Avoid the case where destroy() is called before scheduling timeouts.
+        // See: https://github.com/netty/netty/issues/143
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Initializing autoflush handler on channel {}", ctx.channel());
+        }
+        switch (state) {
+            case 1:
+            case 2:
+                return;
+        }
+
+        state = 1;
+
+        EventExecutor loop = ctx.executor();
+
+        lastExecutionTime = System.nanoTime();
+        resenderTimeout = loop.schedule(new WriterIdleTimeoutTask(ctx), resenderTimeNanos, TimeUnit.NANOSECONDS);
+    }
+
+    private void destroy() {
+        state = 2;
+
+        if (resenderTimeout != null) {
+            resenderTimeout.cancel(false);
+            resenderTimeout = null;
+        }
+    }
+
+    private void resendNotAcked(ChannelHandlerContext ctx/* , IdleStateEvent evt */) {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Flushing idle Netty channel {} for clientId: {}", ctx.channel(),
+                      NettyUtils.clientID(ctx.channel()));
+        }
+        ctx.fireUserEventTriggered(new ResendNotAckedPublishes());
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/InflightResender.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/InflightResender.java
@@ -16,6 +16,7 @@
 
 package com.echostreams.pulsar.mqtt.broker;
 
+import com.echostreams.pulsar.mqtt.broker.utils.NettyUtils;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.EventExecutor;

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/MQTTConnection.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/MQTTConnection.java
@@ -1,0 +1,504 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.security.IAuthenticator;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.mqtt.*;
+import io.netty.handler.timeout.IdleStateHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
+import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
+import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.*;
+import static io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader.from;
+import static io.netty.handler.codec.mqtt.MqttQoS.*;
+
+final class MQTTConnection {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MQTTConnection.class);
+
+    final Channel channel;
+    private BrokerConfiguration brokerConfig;
+    private IAuthenticator authenticator;
+    private SessionRegistry sessionRegistry;
+    private final PostOffice postOffice;
+    private boolean connected;
+    private final AtomicInteger lastPacketId = new AtomicInteger(0);
+
+    MQTTConnection(Channel channel, BrokerConfiguration brokerConfig, IAuthenticator authenticator,
+                   SessionRegistry sessionRegistry, PostOffice postOffice) {
+        this.channel = channel;
+        this.brokerConfig = brokerConfig;
+        this.authenticator = authenticator;
+        this.sessionRegistry = sessionRegistry;
+        this.postOffice = postOffice;
+        this.connected = false;
+    }
+
+    void handleMessage(MqttMessage msg) {
+        MqttMessageType messageType = msg.fixedHeader().messageType();
+        LOG.debug("Received MQTT message, type: {}, channel: {}", messageType, channel);
+        switch (messageType) {
+            case CONNECT:
+                processConnect((MqttConnectMessage) msg);
+                break;
+            case SUBSCRIBE:
+                processSubscribe((MqttSubscribeMessage) msg);
+                break;
+            case UNSUBSCRIBE:
+                processUnsubscribe((MqttUnsubscribeMessage) msg);
+                break;
+            case PUBLISH:
+                processPublish((MqttPublishMessage) msg);
+                break;
+            case PUBREC:
+                processPubRec(msg);
+                break;
+            case PUBCOMP:
+                processPubComp(msg);
+                break;
+            case PUBREL:
+                processPubRel(msg);
+                break;
+            case DISCONNECT:
+                processDisconnect(msg);
+                break;
+            case PUBACK:
+                processPubAck(msg);
+                break;
+            case PINGREQ:
+                MqttFixedHeader pingHeader = new MqttFixedHeader(MqttMessageType.PINGRESP, false, AT_MOST_ONCE,
+                                                                false, 0);
+                MqttMessage pingResp = new MqttMessage(pingHeader);
+                channel.writeAndFlush(pingResp).addListener(CLOSE_ON_FAILURE);
+                break;
+            default:
+                LOG.error("Unknown MessageType: {}, channel: {}", messageType, channel);
+                break;
+        }
+    }
+
+    private void processPubComp(MqttMessage msg) {
+        final int messageID = ((MqttMessageIdVariableHeader) msg.variableHeader()).messageId();
+        final Session session = sessionRegistry.retrieve(getClientId());
+        session.processPubComp(messageID);
+    }
+
+    private void processPubRec(MqttMessage msg) {
+        final int messageID = ((MqttMessageIdVariableHeader) msg.variableHeader()).messageId();
+        final Session session = sessionRegistry.retrieve(getClientId());
+        session.processPubRec(messageID);
+    }
+
+    static MqttMessage pubrel(int messageID) {
+        MqttFixedHeader pubRelHeader = new MqttFixedHeader(MqttMessageType.PUBREL, false, AT_LEAST_ONCE, false, 0);
+        return new MqttMessage(pubRelHeader, from(messageID));
+    }
+
+    private void processPubAck(MqttMessage msg) {
+        final int messageID = ((MqttMessageIdVariableHeader) msg.variableHeader()).messageId();
+        Session session = sessionRegistry.retrieve(getClientId());
+        session.pubAckReceived(messageID);
+    }
+
+    void processConnect(MqttConnectMessage msg) {
+        MqttConnectPayload payload = msg.payload();
+        String clientId = payload.clientIdentifier();
+        final String username = payload.userName();
+        LOG.trace("Processing CONNECT message. CId={} username: {} channel: {}", clientId, username, channel);
+
+        if (isNotProtocolVersion(msg, MqttVersion.MQTT_3_1) && isNotProtocolVersion(msg, MqttVersion.MQTT_3_1_1)) {
+            LOG.warn("MQTT protocol version is not valid. CId={} channel: {}", clientId, channel);
+            abortConnection(CONNECTION_REFUSED_UNACCEPTABLE_PROTOCOL_VERSION);
+            return;
+        }
+        final boolean cleanSession = msg.variableHeader().isCleanSession();
+        if (clientId == null || clientId.length() == 0) {
+            if (!brokerConfig.isAllowZeroByteClientId()) {
+                LOG.warn("Broker doesn't permit MQTT empty client ID. Username: {}, channel: {}", username, channel);
+                abortConnection(CONNECTION_REFUSED_IDENTIFIER_REJECTED);
+                return;
+            }
+
+            if (!cleanSession) {
+                LOG.warn("MQTT client ID cannot be empty for persistent session. Username: {}, channel: {}",
+                         username, channel);
+                abortConnection(CONNECTION_REFUSED_IDENTIFIER_REJECTED);
+                return;
+            }
+
+            // Generating client id.
+            clientId = UUID.randomUUID().toString().replace("-", "");
+            LOG.debug("Client has connected with integration generated id: {}, username: {}, channel: {}", clientId,
+                      username, channel);
+        }
+
+        if (!login(msg, clientId)) {
+            abortConnection(CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD);
+            channel.close().addListener(CLOSE_ON_FAILURE);
+            return;
+        }
+
+        try {
+            LOG.trace("Binding MQTTConnection (channel: {}) to session", channel);
+            sessionRegistry.bindToSession(this, msg, clientId);
+
+            initializeKeepAliveTimeout(channel, msg, clientId);
+            setupInflightResender(channel);
+
+            NettyUtils.clientID(channel, clientId);
+            LOG.trace("CONNACK sent, channel: {}", channel);
+            postOffice.dispatchConnection(msg);
+            LOG.trace("dispatch connection: {}", msg.toString());
+        } catch (SessionCorruptedException scex) {
+            LOG.warn("MQTT session for client ID {} cannot be created, channel: {}", clientId, channel);
+            abortConnection(CONNECTION_REFUSED_SERVER_UNAVAILABLE);
+        }
+    }
+
+    private void setupInflightResender(Channel channel) {
+        channel.pipeline()
+            .addFirst("inflightResender", new InflightResender(5_000, TimeUnit.MILLISECONDS));
+    }
+
+    private void initializeKeepAliveTimeout(Channel channel, MqttConnectMessage msg, String clientId) {
+        int keepAlive = msg.variableHeader().keepAliveTimeSeconds();
+        NettyUtils.keepAlive(channel, keepAlive);
+        NettyUtils.cleanSession(channel, msg.variableHeader().isCleanSession());
+        NettyUtils.clientID(channel, clientId);
+        int idleTime = Math.round(keepAlive * 1.5f);
+        setIdleTime(channel.pipeline(), idleTime);
+
+        LOG.debug("Connection has been configured CId={}, keepAlive={}, removeTemporaryQoS2={}, idleTime={}",
+            clientId, keepAlive, msg.variableHeader().isCleanSession(), idleTime);
+    }
+
+    private void setIdleTime(ChannelPipeline pipeline, int idleTime) {
+        if (pipeline.names().contains("idleStateHandler")) {
+            pipeline.remove("idleStateHandler");
+        }
+        pipeline.addFirst("idleStateHandler", new IdleStateHandler(idleTime, 0, 0));
+    }
+
+    private boolean isNotProtocolVersion(MqttConnectMessage msg, MqttVersion version) {
+        return msg.variableHeader().version() != version.protocolLevel();
+    }
+
+    private void abortConnection(MqttConnectReturnCode returnCode) {
+        MqttConnAckMessage badProto = connAck(returnCode, false);
+        channel.writeAndFlush(badProto).addListener(FIRE_EXCEPTION_ON_FAILURE);
+        channel.close().addListener(CLOSE_ON_FAILURE);
+    }
+
+    private MqttConnAckMessage connAck(MqttConnectReturnCode returnCode, boolean sessionPresent) {
+        MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.CONNACK, false, MqttQoS.AT_MOST_ONCE,
+            false, 0);
+        MqttConnAckVariableHeader mqttConnAckVariableHeader = new MqttConnAckVariableHeader(returnCode, sessionPresent);
+        return new MqttConnAckMessage(mqttFixedHeader, mqttConnAckVariableHeader);
+    }
+
+    private boolean login(MqttConnectMessage msg, final String clientId) {
+        // handle user authentication
+        if (msg.variableHeader().hasUserName()) {
+            byte[] pwd = null;
+            if (msg.variableHeader().hasPassword()) {
+                pwd = msg.payload().password().getBytes(StandardCharsets.UTF_8);
+            } else if (!brokerConfig.isAllowAnonymous()) {
+                LOG.error("Client didn't supply any password and MQTT anonymous mode is disabled CId={}", clientId);
+                return false;
+            }
+            final String login = msg.payload().userName();
+            if (!authenticator.checkValid(clientId, login, pwd)) {
+                LOG.error("Authenticator has rejected the MQTT credentials CId={}, username={}", clientId, login);
+                return false;
+            }
+            NettyUtils.userName(channel, login);
+        } else if (!brokerConfig.isAllowAnonymous()) {
+            LOG.error("Client didn't supply any credentials and MQTT anonymous mode is disabled. CId={}", clientId);
+            return false;
+        }
+        return true;
+    }
+
+    void handleConnectionLost() {
+        String clientID = NettyUtils.clientID(channel);
+        if (clientID == null || clientID.isEmpty()) {
+            return;
+        }
+        LOG.info("Notifying connection lost event. CId: {}, channel: {}", clientID, channel);
+        Session session = sessionRegistry.retrieve(clientID);
+        if (session.hasWill()) {
+            postOffice.fireWill(session.getWill());
+        }
+        if (session.isClean()) {
+            sessionRegistry.remove(clientID);
+        } else {
+            sessionRegistry.disconnect(clientID);
+        }
+        connected = false;
+        //dispatch connection lost to intercept.
+        String userName = NettyUtils.userName(channel);
+        postOffice.dispatchConnectionLost(clientID,userName);
+        LOG.trace("dispatch disconnection: clientId={}, userName={}", clientID, userName);
+    }
+
+    void sendConnAck(boolean isSessionAlreadyPresent) {
+        connected = true;
+        final MqttConnAckMessage ackMessage = connAck(CONNECTION_ACCEPTED, isSessionAlreadyPresent);
+        channel.writeAndFlush(ackMessage).addListener(FIRE_EXCEPTION_ON_FAILURE);
+    }
+
+    boolean isConnected() {
+        return connected;
+    }
+
+    void dropConnection() {
+        channel.close().addListener(FIRE_EXCEPTION_ON_FAILURE);
+    }
+
+    void processDisconnect(MqttMessage msg) {
+        final String clientID = NettyUtils.clientID(channel);
+        LOG.trace("Start DISCONNECT CId={}, channel: {}", clientID, channel);
+        if (!connected) {
+            LOG.info("DISCONNECT received on already closed connection, CId={}, channel: {}", clientID, channel);
+            return;
+        }
+        sessionRegistry.disconnect(clientID);
+        connected = false;
+        channel.close().addListener(FIRE_EXCEPTION_ON_FAILURE);
+        LOG.trace("Processed DISCONNECT CId={}, channel: {}", clientID, channel);
+        String userName = NettyUtils.userName(channel);
+        postOffice.dispatchDisconnection(clientID,userName);
+        LOG.trace("dispatch disconnection: clientId={}, userName={}", clientID, userName);
+    }
+
+    void processSubscribe(MqttSubscribeMessage msg) {
+        final String clientID = NettyUtils.clientID(channel);
+        if (!connected) {
+            LOG.warn("SUBSCRIBE received on already closed connection, CId={}, channel: {}", clientID, channel);
+            dropConnection();
+            return;
+        }
+        postOffice.subscribeClientToTopics(msg, clientID, NettyUtils.userName(channel), this);
+    }
+
+    void sendSubAckMessage(int messageID, MqttSubAckMessage ackMessage) {
+        final String clientId = NettyUtils.clientID(channel);
+        LOG.trace("Sending SUBACK response CId={}, messageId: {}", clientId, messageID);
+        channel.writeAndFlush(ackMessage).addListener(FIRE_EXCEPTION_ON_FAILURE);
+    }
+
+    private void processUnsubscribe(MqttUnsubscribeMessage msg) {
+        List<String> topics = msg.payload().topics();
+        String clientID = NettyUtils.clientID(channel);
+
+        LOG.trace("Processing UNSUBSCRIBE message. CId={}, topics: {}", clientID, topics);
+        postOffice.unsubscribe(topics, this, msg.variableHeader().messageId());
+    }
+
+    void sendUnsubAckMessage(List<String> topics, String clientID, int messageID) {
+        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.UNSUBACK, false, AT_MOST_ONCE,
+            false, 0);
+        MqttUnsubAckMessage ackMessage = new MqttUnsubAckMessage(fixedHeader, from(messageID));
+
+        LOG.trace("Sending UNSUBACK message. CId={}, messageId: {}, topics: {}", clientID, messageID, topics);
+        channel.writeAndFlush(ackMessage).addListener(FIRE_EXCEPTION_ON_FAILURE);
+        LOG.trace("Client <{}> unsubscribed from topics <{}>", clientID, topics);
+    }
+
+    void processPublish(MqttPublishMessage msg) {
+        final MqttQoS qos = msg.fixedHeader().qosLevel();
+        final String username = NettyUtils.userName(channel);
+        final String topicName = msg.variableHeader().topicName();
+        final String clientId = getClientId();
+        LOG.trace("Processing PUBLISH message. CId={}, topic: {}, messageId: {}, qos: {}", clientId, topicName,
+                  msg.variableHeader().packetId(), qos);
+        ByteBuf payload = msg.payload();
+        final boolean retain = msg.fixedHeader().isRetain();
+        final Topic topic = new Topic(topicName);
+        if (!topic.isValid()) {
+            LOG.debug("Drop connection because of invalid topic format");
+            dropConnection();
+        }
+        switch (qos) {
+            case AT_MOST_ONCE:
+                postOffice.receivedPublishQos0(topic, username, clientId, payload, retain, msg);
+                break;
+            case AT_LEAST_ONCE: {
+                final int messageID = msg.variableHeader().packetId();
+                postOffice.receivedPublishQos1(this, topic, username, payload, messageID, retain, msg);
+                break;
+            }
+            case EXACTLY_ONCE: {
+                final int messageID = msg.variableHeader().packetId();
+                final Session session = sessionRegistry.retrieve(clientId);
+                session.receivedPublishQos2(messageID, msg);
+                postOffice.receivedPublishQos2(this, msg, username);
+//                msg.release();
+                break;
+            }
+            default:
+                LOG.error("Unknown QoS-Type:{}", qos);
+                break;
+        }
+    }
+
+    void sendPublishReceived(int messageID) {
+        LOG.trace("sendPubRec invoked on channel: {}", channel);
+        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBREC, false, AT_MOST_ONCE,
+            false, 0);
+        MqttPubAckMessage pubRecMessage = new MqttPubAckMessage(fixedHeader, from(messageID));
+        sendIfWritableElseDrop(pubRecMessage);
+    }
+
+    private void processPubRel(MqttMessage msg) {
+        final Session session = sessionRegistry.retrieve(getClientId());
+        final int messageID = ((MqttMessageIdVariableHeader) msg.variableHeader()).messageId();
+        session.receivedPubRelQos2(messageID);
+        sendPubCompMessage(messageID);
+    }
+
+    void sendPublish(MqttPublishMessage publishMsg) {
+        final int packetId = publishMsg.variableHeader().packetId();
+        final String topicName = publishMsg.variableHeader().topicName();
+        final String clientId = getClientId();
+        MqttQoS qos = publishMsg.fixedHeader().qosLevel();
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Sending PUBLISH({}) message. MessageId={}, CId={}, topic={}, payload={}", qos, packetId,
+                      clientId, topicName, DebugUtils.payload2Str(publishMsg.payload()));
+        } else {
+            LOG.debug("Sending PUBLISH({}) message. MessageId={}, CId={}, topic={}", qos, packetId, clientId,
+                      topicName);
+        }
+        sendIfWritableElseDrop(publishMsg);
+    }
+
+    void sendIfWritableElseDrop(MqttMessage msg) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("OUT {} on channel {}", msg.fixedHeader().messageType(), channel);
+        }
+        if (channel.isWritable()) {
+            ChannelFuture channelFuture;
+            if (brokerConfig.isImmediateBufferFlush()) {
+                channelFuture = channel.writeAndFlush(msg);
+            }
+            else {
+                channelFuture = channel.write(msg);
+            }
+            channelFuture.addListener(FIRE_EXCEPTION_ON_FAILURE);
+        }
+    }
+
+    public void writabilityChanged() {
+        if (channel.isWritable()) {
+            LOG.debug("Channel {} is again writable", channel);
+            final Session session = sessionRegistry.retrieve(getClientId());
+            session.writabilityChanged();
+        }
+    }
+
+    void sendPubAck(int messageID) {
+        LOG.trace("sendPubAck invoked");
+        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBACK, false, AT_MOST_ONCE,
+                                                  false, 0);
+        MqttPubAckMessage pubAckMessage = new MqttPubAckMessage(fixedHeader, from(messageID));
+        sendIfWritableElseDrop(pubAckMessage);
+    }
+
+    private void sendPubCompMessage(int messageID) {
+        LOG.trace("Sending PUBCOMP message on channel: {}, messageId: {}", channel, messageID);
+        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBCOMP, false, AT_MOST_ONCE, false, 0);
+        MqttMessage pubCompMessage = new MqttMessage(fixedHeader, from(messageID));
+        sendIfWritableElseDrop(pubCompMessage);
+    }
+
+    String getClientId() {
+        return NettyUtils.clientID(channel);
+    }
+
+    String getUsername() {
+        return NettyUtils.userName(channel);
+    }
+
+    public void sendPublishRetainedQos0(Topic topic, MqttQoS qos, ByteBuf payload) {
+        MqttPublishMessage publishMsg = retainedPublish(topic.toString(), qos, payload);
+        sendPublish(publishMsg);
+    }
+
+    public void sendPublishRetainedWithPacketId(Topic topic, MqttQoS qos, ByteBuf payload) {
+        final int packetId = nextPacketId();
+        MqttPublishMessage publishMsg = retainedPublishWithMessageId(topic.toString(), qos, payload, packetId);
+        sendPublish(publishMsg);
+    }
+
+    private static MqttPublishMessage retainedPublish(String topic, MqttQoS qos, ByteBuf message) {
+        return retainedPublishWithMessageId(topic, qos, message, 0);
+    }
+
+    private static MqttPublishMessage retainedPublishWithMessageId(String topic, MqttQoS qos, ByteBuf message,
+                                                                   int messageId) {
+        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, qos, true, 0);
+        MqttPublishVariableHeader varHeader = new MqttPublishVariableHeader(topic, messageId);
+        return new MqttPublishMessage(fixedHeader, varHeader, message);
+    }
+
+    // TODO move this method in Session
+    void sendPublishNotRetainedQos0(Topic topic, MqttQoS qos, ByteBuf payload) {
+        MqttPublishMessage publishMsg = notRetainedPublish(topic.toString(), qos, payload);
+        sendPublish(publishMsg);
+    }
+
+    static MqttPublishMessage notRetainedPublish(String topic, MqttQoS qos, ByteBuf message) {
+        return notRetainedPublishWithMessageId(topic, qos, message, 0);
+    }
+
+    static MqttPublishMessage notRetainedPublishWithMessageId(String topic, MqttQoS qos, ByteBuf message,
+                                                              int messageId) {
+        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, qos, false, 0);
+        MqttPublishVariableHeader varHeader = new MqttPublishVariableHeader(topic, messageId);
+        return new MqttPublishMessage(fixedHeader, varHeader, message);
+    }
+
+    public void resendNotAckedPublishes() {
+        final Session session = sessionRegistry.retrieve(getClientId());
+        session.resendInflightNotAcked();
+    }
+
+    int nextPacketId() {
+        return lastPacketId.incrementAndGet();
+    }
+
+    @Override
+    public String toString() {
+        return "MQTTConnection{channel=" + channel + ", connected=" + connected + '}';
+    }
+
+    InetSocketAddress remoteAddress() {
+        return (InetSocketAddress) channel.remoteAddress();
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/MQTTConnection.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/MQTTConnection.java
@@ -17,6 +17,7 @@ package com.echostreams.pulsar.mqtt.broker;
 
 import com.echostreams.pulsar.mqtt.broker.security.IAuthenticator;
 import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import com.echostreams.pulsar.mqtt.broker.utils.NettyUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/MQTTConnectionFactory.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/MQTTConnectionFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.security.IAuthenticator;
+import io.netty.channel.Channel;
+
+class MQTTConnectionFactory {
+
+    private final BrokerConfiguration brokerConfig;
+    private final IAuthenticator authenticator;
+    private final SessionRegistry sessionRegistry;
+    private final PostOffice postOffice;
+
+    MQTTConnectionFactory(BrokerConfiguration brokerConfig, IAuthenticator authenticator,
+                          SessionRegistry sessionRegistry, PostOffice postOffice) {
+        this.brokerConfig = brokerConfig;
+        this.authenticator = authenticator;
+        this.sessionRegistry = sessionRegistry;
+        this.postOffice = postOffice;
+    }
+
+    MQTTConnection create(Channel channel) {
+        return new MQTTConnection(channel, brokerConfig, authenticator, sessionRegistry, postOffice);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/MemoryQueueRepository.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/MemoryQueueRepository.java
@@ -1,0 +1,12 @@
+package com.echostreams.pulsar.mqtt.broker;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class MemoryQueueRepository implements IQueueRepository {
+
+    @Override
+    public Queue<SessionRegistry.EnqueuedMessage> createQueue(String cli, boolean clean) {
+        return new ConcurrentLinkedQueue<>();
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/MemoryRetainedRepository.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/MemoryRetainedRepository.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/*
+* In memory retained messages store
+* */
+final class MemoryRetainedRepository implements IRetainedRepository {
+
+    private final ConcurrentMap<Topic, RetainedMessage> storage = new ConcurrentHashMap<>();
+
+    @Override
+    public void cleanRetained(Topic topic) {
+        storage.remove(topic);
+    }
+
+    @Override
+    public void retain(Topic topic, MqttPublishMessage msg) {
+        final ByteBuf payload = msg.content();
+        byte[] rawPayload = new byte[payload.readableBytes()];
+        payload.getBytes(0, rawPayload);
+        final RetainedMessage toStore = new RetainedMessage(msg.fixedHeader().qosLevel(), rawPayload);
+        storage.put(topic, toStore);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return storage.isEmpty();
+    }
+
+    @Override
+    public List<RetainedMessage> retainedOnTopic(String topic) {
+        final Topic searchTopic = new Topic(topic);
+        final List<RetainedMessage> matchingMessages = new ArrayList<>();
+        for (Map.Entry<Topic, RetainedMessage> entry : storage.entrySet()) {
+            final Topic scanTopic = entry.getKey();
+            if (searchTopic.match(scanTopic)) {
+                matchingMessages.add(entry.getValue());
+            }
+        }
+        return matchingMessages;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/MoquetteIdleTimeoutHandler.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/MoquetteIdleTimeoutHandler.java
@@ -16,6 +16,7 @@
 
 package com.echostreams.pulsar.mqtt.broker;
 
+import com.echostreams.pulsar.mqtt.broker.utils.NettyUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.netty.channel.ChannelDuplexHandler;

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/MoquetteIdleTimeoutHandler.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/MoquetteIdleTimeoutHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.timeout.IdleState;
+import io.netty.handler.timeout.IdleStateEvent;
+
+import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
+
+@Sharable
+public class MoquetteIdleTimeoutHandler extends ChannelDuplexHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MoquetteIdleTimeoutHandler.class);
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof IdleStateEvent) {
+            IdleState e = ((IdleStateEvent) evt).state();
+            if (e == IdleState.READER_IDLE) {
+                LOG.info("Firing channel inactive event. MqttClientId = {}.", NettyUtils.clientID(ctx.channel()));
+                // fire a close that then fire channelInactive to trigger publish of Will
+                ctx.close().addListener(CLOSE_ON_FAILURE);
+            }
+        } else {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Firing Netty event CId = {}, eventClass = {}", NettyUtils.clientID(ctx.channel()),
+                          evt.getClass().getName());
+            }
+            super.userEventTriggered(ctx, evt);
+        }
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/NettyUtils.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/NettyUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker;
+
+import java.io.IOException;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+
+/**
+ * Some Netty's channels utilities.
+ */
+public final class NettyUtils {
+
+    public static final String ATTR_USERNAME = "username";
+
+    private static final String ATTR_CLIENTID = "ClientID";
+    private static final String CLEAN_SESSION = "removeTemporaryQoS2";
+    private static final String KEEP_ALIVE = "keepAlive";
+    private static final AttributeKey<Object> ATTR_KEY_KEEPALIVE = AttributeKey.valueOf(KEEP_ALIVE);
+    private static final AttributeKey<Object> ATTR_KEY_CLEANSESSION = AttributeKey.valueOf(CLEAN_SESSION);
+    private static final AttributeKey<Object> ATTR_KEY_CLIENTID = AttributeKey.valueOf(ATTR_CLIENTID);
+    private static final AttributeKey<Object> ATTR_KEY_USERNAME = AttributeKey.valueOf(ATTR_USERNAME);
+
+    public static Object getAttribute(ChannelHandlerContext ctx, AttributeKey<Object> key) {
+        Attribute<Object> attr = ctx.channel().attr(key);
+        return attr.get();
+    }
+
+    public static void keepAlive(Channel channel, int keepAlive) {
+        channel.attr(NettyUtils.ATTR_KEY_KEEPALIVE).set(keepAlive);
+    }
+
+    public static void cleanSession(Channel channel, boolean cleanSession) {
+        channel.attr(NettyUtils.ATTR_KEY_CLEANSESSION).set(cleanSession);
+    }
+
+    public static boolean cleanSession(Channel channel) {
+        return (Boolean) channel.attr(NettyUtils.ATTR_KEY_CLEANSESSION).get();
+    }
+
+    public static void clientID(Channel channel, String clientID) {
+        channel.attr(NettyUtils.ATTR_KEY_CLIENTID).set(clientID);
+    }
+
+    public static String clientID(Channel channel) {
+        return (String) channel.attr(NettyUtils.ATTR_KEY_CLIENTID).get();
+    }
+
+    public static void userName(Channel channel, String username) {
+        channel.attr(NettyUtils.ATTR_KEY_USERNAME).set(username);
+    }
+
+    public static String userName(Channel channel) {
+        return (String) channel.attr(NettyUtils.ATTR_KEY_USERNAME).get();
+    }
+
+    /**
+	 * Validate that the provided message is an MqttMessage and that it does not contain a failed result.
+	 *
+	 * @param message to be validated
+	 * @return the casted provided message
+	 * @throws IOException in case of an fail message this will wrap the root cause
+	 * @throws ClassCastException if the provided message is no MqttMessage
+	 */
+	public static MqttMessage validateMessage(Object message) throws IOException, ClassCastException {
+		MqttMessage msg = (MqttMessage) message;
+		if (msg.decoderResult() != null && msg.decoderResult().isFailure()) {
+			throw new IOException("invalid massage", msg.decoderResult().cause());
+		}
+		if (msg.fixedHeader() == null) {
+			throw new IOException("Unknown packet, no fixedHeader present, no cause provided");
+		}
+		return msg;
+	}
+
+	private NettyUtils() {
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/NewNettyAcceptor.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/NewNettyAcceptor.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import com.echostreams.pulsar.mqtt.broker.metrics.*;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.*;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.handler.codec.mqtt.MqttDecoder;
+import io.netty.handler.codec.mqtt.MqttEncoder;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.concurrent.Future;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLEngine;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
+
+class NewNettyAcceptor {
+
+    private static final String MQTT_SUBPROTOCOL_CSV_LIST = "mqtt, mqttv3.1, mqttv3.1.1";
+    public static final String PLAIN_MQTT_PROTO = "TCP MQTT";
+    public static final String SSL_MQTT_PROTO = "SSL MQTT";
+
+    static class WebSocketFrameToByteBufDecoder extends MessageToMessageDecoder<BinaryWebSocketFrame> {
+
+        @Override
+        protected void decode(ChannelHandlerContext chc, BinaryWebSocketFrame frame, List<Object> out)
+                throws Exception {
+            // convert the frame to a ByteBuf
+            ByteBuf bb = frame.content();
+            // System.out.println("WebSocketFrameToByteBufDecoder decode - " +
+            // ByteBufUtil.hexDump(bb));
+            bb.retain();
+            out.add(bb);
+        }
+    }
+
+    static class ByteBufToWebSocketFrameEncoder extends MessageToMessageEncoder<ByteBuf> {
+
+        @Override
+        protected void encode(ChannelHandlerContext chc, ByteBuf bb, List<Object> out) throws Exception {
+            // convert the ByteBuf to a WebSocketFrame
+            BinaryWebSocketFrame result = new BinaryWebSocketFrame();
+            // System.out.println("ByteBufToWebSocketFrameEncoder encode - " +
+            // ByteBufUtil.hexDump(bb));
+            result.content().writeBytes(bb);
+            out.add(result);
+        }
+    }
+
+    private abstract static class PipelineInitializer {
+
+        abstract void init(SocketChannel channel) throws Exception;
+    }
+
+
+    private class LocalPortReaderFutureListener implements ChannelFutureListener {
+        private String transportName;
+
+        LocalPortReaderFutureListener(String transportName) {
+            this.transportName = transportName;
+        }
+
+        @Override
+        public void operationComplete(ChannelFuture future) throws Exception {
+            if (future.isSuccess()) {
+                final SocketAddress localAddress = future.channel().localAddress();
+                if (localAddress instanceof InetSocketAddress) {
+                    InetSocketAddress inetAddress = (InetSocketAddress) localAddress;
+                    LOG.debug("bound {} port: {}", transportName, inetAddress.getPort());
+                    int port = inetAddress.getPort();
+                    ports.put(transportName, port);
+                }
+            }
+        }
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(NewNettyAcceptor.class);
+
+    private EventLoopGroup bossGroup;
+    private EventLoopGroup workerGroup;
+    private final Map<String, Integer> ports = new HashMap<>();
+    private BytesMetricsCollector bytesMetricsCollector = new BytesMetricsCollector();
+    private MessageMetricsCollector metricsCollector = new MessageMetricsCollector();
+    private Optional<? extends ChannelInboundHandler> metrics;
+    private Optional<? extends ChannelInboundHandler> errorsCather;
+
+    private int nettySoBacklog;
+    private boolean nettySoReuseaddr;
+    private boolean nettyTcpNodelay;
+    private boolean nettySoKeepalive;
+    private int nettyChannelTimeoutSeconds;
+    private int maxBytesInMessage;
+
+    private Class<? extends ServerSocketChannel> channelClass;
+
+    public void initialize(NewNettyMQTTHandler mqttHandler, IConfig props, ISslContextCreator sslCtxCreator) {
+        LOG.debug("Initializing Netty acceptor");
+
+        nettySoBacklog = props.intProp(BrokerConstants.NETTY_SO_BACKLOG_PROPERTY_NAME, 128);
+        nettySoReuseaddr = props.boolProp(BrokerConstants.NETTY_SO_REUSEADDR_PROPERTY_NAME, true);
+        nettyTcpNodelay = props.boolProp(BrokerConstants.NETTY_TCP_NODELAY_PROPERTY_NAME, true);
+        nettySoKeepalive = props.boolProp(BrokerConstants.NETTY_SO_KEEPALIVE_PROPERTY_NAME, true);
+        nettyChannelTimeoutSeconds = props.intProp(BrokerConstants.NETTY_CHANNEL_TIMEOUT_SECONDS_PROPERTY_NAME, 10);
+        maxBytesInMessage = props.intProp(BrokerConstants.NETTY_MAX_BYTES_PROPERTY_NAME,
+                BrokerConstants.DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE);
+
+        boolean epoll = props.boolProp(BrokerConstants.NETTY_EPOLL_PROPERTY_NAME, false);
+        if (epoll) {
+            LOG.info("Netty is using Epoll");
+            bossGroup = new EpollEventLoopGroup();
+            workerGroup = new EpollEventLoopGroup();
+            channelClass = EpollServerSocketChannel.class;
+        } else {
+            LOG.info("Netty is using NIO");
+            bossGroup = new NioEventLoopGroup();
+            workerGroup = new NioEventLoopGroup();
+            channelClass = NioServerSocketChannel.class;
+        }
+
+        final boolean useFineMetrics = props.boolProp(BrokerConstants.METRICS_ENABLE_PROPERTY_NAME, false);
+        if (useFineMetrics) {
+            DropWizardMetricsHandler metricsHandler = new DropWizardMetricsHandler();
+            metricsHandler.init(props);
+            this.metrics = Optional.of(metricsHandler);
+        } else {
+            this.metrics = Optional.empty();
+        }
+
+        final boolean useBugSnag = props.boolProp(BrokerConstants.BUGSNAG_ENABLE_PROPERTY_NAME, false);
+        if (useBugSnag) {
+            BugSnagErrorsHandler bugSnagHandler = new BugSnagErrorsHandler();
+            bugSnagHandler.init(props);
+            this.errorsCather = Optional.of(bugSnagHandler);
+        } else {
+            this.errorsCather = Optional.empty();
+        }
+        initializePlainTCPTransport(mqttHandler, props);
+        initializeWebSocketTransport(mqttHandler, props);
+        if (securityPortsConfigured(props)) {
+            SslContext sslContext = sslCtxCreator.initSSLContext();
+            if (sslContext == null) {
+                LOG.error("Can't initialize SSLHandler layer! Exiting, check your configuration of jks");
+                return;
+            }
+            initializeSSLTCPTransport(mqttHandler, props, sslContext);
+            initializeWSSTransport(mqttHandler, props, sslContext);
+        }
+    }
+
+    private boolean securityPortsConfigured(IConfig props) {
+        String sslTcpPortProp = props.getProperty(BrokerConstants.SSL_PORT_PROPERTY_NAME);
+        String wssPortProp = props.getProperty(BrokerConstants.WSS_PORT_PROPERTY_NAME);
+        return sslTcpPortProp != null || wssPortProp != null;
+    }
+
+    private void initFactory(String host, int port, String protocol, final PipelineInitializer pipelieInitializer) {
+        LOG.debug("Initializing integration. Protocol={}", protocol);
+        ServerBootstrap b = new ServerBootstrap();
+        b.group(bossGroup, workerGroup).channel(channelClass)
+                .childHandler(new ChannelInitializer<SocketChannel>() {
+
+                    @Override
+                    public void initChannel(SocketChannel ch) throws Exception {
+                        pipelieInitializer.init(ch);
+                    }
+                })
+                .option(ChannelOption.SO_BACKLOG, nettySoBacklog)
+                .option(ChannelOption.SO_REUSEADDR, nettySoReuseaddr)
+                .childOption(ChannelOption.TCP_NODELAY, nettyTcpNodelay)
+                .childOption(ChannelOption.SO_KEEPALIVE, nettySoKeepalive);
+        try {
+            LOG.debug("Binding integration. host={}, port={}", host, port);
+            // Bind and start to accept incoming connections.
+            ChannelFuture f = b.bind(host, port);
+            LOG.info("Server bound to host={}, port={}, protocol={}", host, port, protocol);
+            f.sync()
+                .addListener(new LocalPortReaderFutureListener(protocol))
+                .addListener(FIRE_EXCEPTION_ON_FAILURE);
+        } catch (InterruptedException ex) {
+            LOG.error("An interruptedException was caught while initializing integration. Protocol={}", protocol, ex);
+        }
+    }
+
+    public int getPort() {
+        return ports.computeIfAbsent(PLAIN_MQTT_PROTO, i -> 0);
+    }
+
+    public int getSslPort() {
+        return ports.computeIfAbsent(SSL_MQTT_PROTO, i -> 0);
+    }
+
+    private void initializePlainTCPTransport(NewNettyMQTTHandler handler, IConfig props) {
+        LOG.debug("Configuring TCP MQTT transport");
+        final MoquetteIdleTimeoutHandler timeoutHandler = new MoquetteIdleTimeoutHandler();
+        String host = props.getProperty(BrokerConstants.HOST_PROPERTY_NAME);
+        String tcpPortProp = props.getProperty(BrokerConstants.PORT_PROPERTY_NAME, BrokerConstants.DISABLED_PORT_BIND);
+        if (BrokerConstants.DISABLED_PORT_BIND.equals(tcpPortProp)) {
+            LOG.info("Property {} has been set to {}. TCP MQTT will be disabled", BrokerConstants.PORT_PROPERTY_NAME,
+                     BrokerConstants.DISABLED_PORT_BIND);
+            return;
+        }
+        int port = Integer.parseInt(tcpPortProp);
+        initFactory(host, port, PLAIN_MQTT_PROTO, new PipelineInitializer() {
+
+            @Override
+            void init(SocketChannel channel) {
+                ChannelPipeline pipeline = channel.pipeline();
+                configureMQTTPipeline(pipeline, timeoutHandler, handler);
+            }
+        });
+    }
+
+    private void configureMQTTPipeline(ChannelPipeline pipeline, MoquetteIdleTimeoutHandler timeoutHandler,
+                                       NewNettyMQTTHandler handler) {
+        pipeline.addFirst("idleStateHandler", new IdleStateHandler(nettyChannelTimeoutSeconds, 0, 0));
+        pipeline.addAfter("idleStateHandler", "idleEventHandler", timeoutHandler);
+        // pipeline.addLast("logger", new LoggingHandler("Netty", LogLevel.ERROR));
+        if (errorsCather.isPresent()) {
+            pipeline.addLast("bugsnagCatcher", errorsCather.get());
+        }
+        pipeline.addFirst("bytemetrics", new BytesMetricsHandler(bytesMetricsCollector));
+        pipeline.addLast("autoflush", new AutoFlushHandler(1, TimeUnit.SECONDS));
+        pipeline.addLast("decoder", new MqttDecoder(maxBytesInMessage));
+        pipeline.addLast("encoder", MqttEncoder.INSTANCE);
+        pipeline.addLast("metrics", new MessageMetricsHandler(metricsCollector));
+        pipeline.addLast("messageLogger", new MQTTMessageLogger());
+        if (metrics.isPresent()) {
+            pipeline.addLast("wizardMetrics", metrics.get());
+        }
+        pipeline.addLast("handler", handler);
+    }
+
+    private void initializeWebSocketTransport(final NewNettyMQTTHandler handler, IConfig props) {
+        LOG.debug("Configuring Websocket MQTT transport");
+        String webSocketPortProp = props.getProperty(BrokerConstants.WEB_SOCKET_PORT_PROPERTY_NAME, BrokerConstants.DISABLED_PORT_BIND);
+        if (BrokerConstants.DISABLED_PORT_BIND.equals(webSocketPortProp)) {
+            // Do nothing no WebSocket configured
+            LOG.info("Property {} has been setted to {}. Websocket MQTT will be disabled",
+                     BrokerConstants.WEB_SOCKET_PORT_PROPERTY_NAME, BrokerConstants.DISABLED_PORT_BIND);
+            return;
+        }
+        int port = Integer.parseInt(webSocketPortProp);
+
+        final MoquetteIdleTimeoutHandler timeoutHandler = new MoquetteIdleTimeoutHandler();
+
+        String host = props.getProperty(BrokerConstants.HOST_PROPERTY_NAME);
+        String path = props.getProperty(BrokerConstants.WEB_SOCKET_PATH_PROPERTY_NAME, BrokerConstants.WEBSOCKET_PATH);
+        int maxFrameSize = props.intProp(BrokerConstants.WEB_SOCKET_MAX_FRAME_SIZE_PROPERTY_NAME, 65536);
+        initFactory(host, port, "Websocket MQTT", new PipelineInitializer() {
+
+            @Override
+            void init(SocketChannel channel) {
+                ChannelPipeline pipeline = channel.pipeline();
+                pipeline.addLast(new HttpServerCodec());
+                pipeline.addLast("aggregator", new HttpObjectAggregator(65536));
+                pipeline.addLast("webSocketHandler",
+                        new WebSocketServerProtocolHandler(path, MQTT_SUBPROTOCOL_CSV_LIST, false, maxFrameSize));
+                pipeline.addLast("ws2bytebufDecoder", new WebSocketFrameToByteBufDecoder());
+                pipeline.addLast("bytebuf2wsEncoder", new ByteBufToWebSocketFrameEncoder());
+                configureMQTTPipeline(pipeline, timeoutHandler, handler);
+            }
+        });
+    }
+
+    private void initializeSSLTCPTransport(NewNettyMQTTHandler handler, IConfig props, SslContext sslContext) {
+        LOG.debug("Configuring SSL MQTT transport");
+        String sslPortProp = props.getProperty(BrokerConstants.SSL_PORT_PROPERTY_NAME, BrokerConstants.DISABLED_PORT_BIND);
+        if (BrokerConstants.DISABLED_PORT_BIND.equals(sslPortProp)) {
+            // Do nothing no SSL configured
+            LOG.info("Property {} has been set to {}. SSL MQTT will be disabled",
+                     BrokerConstants.SSL_PORT_PROPERTY_NAME, BrokerConstants.DISABLED_PORT_BIND);
+            return;
+        }
+
+        int sslPort = Integer.parseInt(sslPortProp);
+        LOG.debug("Starting SSL on port {}", sslPort);
+
+        final MoquetteIdleTimeoutHandler timeoutHandler = new MoquetteIdleTimeoutHandler();
+        String host = props.getProperty(BrokerConstants.HOST_PROPERTY_NAME);
+        String sNeedsClientAuth = props.getProperty(BrokerConstants.NEED_CLIENT_AUTH, "false");
+        final boolean needsClientAuth = Boolean.valueOf(sNeedsClientAuth);
+        initFactory(host, sslPort, SSL_MQTT_PROTO, new PipelineInitializer() {
+
+            @Override
+            void init(SocketChannel channel) throws Exception {
+                ChannelPipeline pipeline = channel.pipeline();
+                pipeline.addLast("ssl", createSslHandler(channel, sslContext, needsClientAuth));
+                configureMQTTPipeline(pipeline, timeoutHandler, handler);
+            }
+        });
+    }
+
+    private void initializeWSSTransport(NewNettyMQTTHandler handler, IConfig props, SslContext sslContext) {
+        LOG.debug("Configuring secure websocket MQTT transport");
+        String sslPortProp = props.getProperty(BrokerConstants.WSS_PORT_PROPERTY_NAME, BrokerConstants.DISABLED_PORT_BIND);
+        if (BrokerConstants.DISABLED_PORT_BIND.equals(sslPortProp)) {
+            // Do nothing no SSL configured
+            LOG.info("Property {} has been set to {}. Secure websocket MQTT will be disabled",
+                    BrokerConstants.WSS_PORT_PROPERTY_NAME, BrokerConstants.DISABLED_PORT_BIND);
+            return;
+        }
+        int sslPort = Integer.parseInt(sslPortProp);
+        final MoquetteIdleTimeoutHandler timeoutHandler = new MoquetteIdleTimeoutHandler();
+        String host = props.getProperty(BrokerConstants.HOST_PROPERTY_NAME);
+        String path = props.getProperty(BrokerConstants.WEB_SOCKET_PATH_PROPERTY_NAME, BrokerConstants.WEBSOCKET_PATH);
+        int maxFrameSize = props.intProp(BrokerConstants.WEB_SOCKET_MAX_FRAME_SIZE_PROPERTY_NAME, 65536);
+        String sNeedsClientAuth = props.getProperty(BrokerConstants.NEED_CLIENT_AUTH, "false");
+        final boolean needsClientAuth = Boolean.valueOf(sNeedsClientAuth);
+        initFactory(host, sslPort, "Secure websocket", new PipelineInitializer() {
+
+            @Override
+            void init(SocketChannel channel) throws Exception {
+                ChannelPipeline pipeline = channel.pipeline();
+                pipeline.addLast("ssl", createSslHandler(channel, sslContext, needsClientAuth));
+                pipeline.addLast("httpEncoder", new HttpResponseEncoder());
+                pipeline.addLast("httpDecoder", new HttpRequestDecoder());
+                pipeline.addLast("aggregator", new HttpObjectAggregator(65536));
+                pipeline.addLast("webSocketHandler",
+                        new WebSocketServerProtocolHandler(path, MQTT_SUBPROTOCOL_CSV_LIST, false, maxFrameSize));
+                pipeline.addLast("ws2bytebufDecoder", new WebSocketFrameToByteBufDecoder());
+                pipeline.addLast("bytebuf2wsEncoder", new ByteBufToWebSocketFrameEncoder());
+
+                configureMQTTPipeline(pipeline, timeoutHandler, handler);
+            }
+        });
+    }
+
+    @SuppressWarnings("FutureReturnValueIgnored")
+    public void close() {
+        LOG.debug("Closing Netty acceptor...");
+        if (workerGroup == null || bossGroup == null) {
+            LOG.error("Netty acceptor is not initialized");
+            throw new IllegalStateException("Invoked close on an Acceptor that wasn't initialized");
+        }
+        Future<?> workerWaiter = workerGroup.shutdownGracefully();
+        Future<?> bossWaiter = bossGroup.shutdownGracefully();
+
+        /*
+         * We shouldn't raise an IllegalStateException if we are interrupted. If we did so, the
+         * broker is not shut down properly.
+         */
+        LOG.info("Waiting for worker and boss event loop groups to terminate...");
+        try {
+            workerWaiter.await(10, TimeUnit.SECONDS);
+            bossWaiter.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException iex) {
+            LOG.warn("An InterruptedException was caught while waiting for event loops to terminate...");
+        }
+
+        if (!workerGroup.isTerminated()) {
+            LOG.warn("Forcing shutdown of worker event loop...");
+            workerGroup.shutdownGracefully(0L, 0L, TimeUnit.MILLISECONDS);
+        }
+
+        if (!bossGroup.isTerminated()) {
+            LOG.warn("Forcing shutdown of boss event loop...");
+            bossGroup.shutdownGracefully(0L, 0L, TimeUnit.MILLISECONDS);
+        }
+
+        MessageMetrics metrics = metricsCollector.computeMetrics();
+        BytesMetrics bytesMetrics = bytesMetricsCollector.computeMetrics();
+        LOG.info("Metrics messages[read={}, write={}] bytes[read={}, write={}]", metrics.messagesRead(),
+                 metrics.messagesWrote(), bytesMetrics.readBytes(), bytesMetrics.wroteBytes());
+    }
+
+    private ChannelHandler createSslHandler(SocketChannel channel, SslContext sslContext, boolean needsClientAuth) {
+        SSLEngine sslEngine = sslContext.newEngine(
+                channel.alloc(),
+                channel.remoteAddress().getHostString(),
+                channel.remoteAddress().getPort());
+        sslEngine.setUseClientMode(false);
+        if (needsClientAuth) {
+            sslEngine.setNeedClientAuth(true);
+        }
+        return new SslHandler(sslEngine);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/NewNettyMQTTHandler.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/NewNettyMQTTHandler.java
@@ -16,6 +16,7 @@
 
 package com.echostreams.pulsar.mqtt.broker;
 
+import com.echostreams.pulsar.mqtt.broker.utils.NettyUtils;
 import io.netty.channel.*;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.handler.codec.mqtt.MqttMessage;

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/NewNettyMQTTHandler.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/NewNettyMQTTHandler.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker;
+
+import io.netty.channel.*;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.util.AttributeKey;
+import io.netty.util.ReferenceCountUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
+
+@Sharable
+public class NewNettyMQTTHandler extends ChannelInboundHandlerAdapter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NewNettyMQTTHandler.class);
+
+    private static final String ATTR_CONNECTION = "connection";
+    private static final AttributeKey<Object> ATTR_KEY_CONNECTION = AttributeKey.valueOf(ATTR_CONNECTION);
+
+    private MQTTConnectionFactory connectionFactory;
+
+    NewNettyMQTTHandler(MQTTConnectionFactory connectionFactory) {
+        this.connectionFactory = connectionFactory;
+    }
+
+    private static void mqttConnection(Channel channel, MQTTConnection connection) {
+        channel.attr(ATTR_KEY_CONNECTION).set(connection);
+    }
+
+    private static MQTTConnection mqttConnection(Channel channel) {
+        return (MQTTConnection) channel.attr(ATTR_KEY_CONNECTION).get();
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object message) throws Exception {
+        MqttMessage msg = NettyUtils.validateMessage(message);
+        final MQTTConnection mqttConnection = mqttConnection(ctx.channel());
+        try {
+            mqttConnection.handleMessage(msg);
+        } catch (Throwable ex) {
+            //ctx.fireExceptionCaught(ex);
+            LOG.error("Error processing protocol message: {}", msg.fixedHeader().messageType(), ex);
+            ctx.channel().close().addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture future) {
+                    LOG.info("Closed client channel due to exception in processing");
+                }
+            });
+        } finally {
+            ReferenceCountUtil.release(msg);
+        }
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        MQTTConnection connection = connectionFactory.create(ctx.channel());
+        mqttConnection(ctx.channel(), connection);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        final MQTTConnection mqttConnection = mqttConnection(ctx.channel());
+        mqttConnection.handleConnectionLost();
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        LOG.error("Unexpected exception while processing MQTT message. Closing Netty channel. CId={}",
+                  NettyUtils.clientID(ctx.channel()), cause);
+        ctx.close().addListener(CLOSE_ON_FAILURE);
+    }
+
+    @Override
+    public void channelWritabilityChanged(ChannelHandlerContext ctx) {
+//        if (ctx.channel().isWritable()) {
+//            m_processor.notifyChannelWritable(ctx.channel());
+//        }
+        final MQTTConnection mqttConnection = mqttConnection(ctx.channel());
+        mqttConnection.writabilityChanged();
+        ctx.fireChannelWritabilityChanged();
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        if (evt instanceof InflightResender.ResendNotAckedPublishes) {
+            final MQTTConnection mqttConnection = mqttConnection(ctx.channel());
+            mqttConnection.resendNotAckedPublishes();
+        }
+        ctx.fireUserEventTriggered(evt);
+    }
+
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/PostOffice.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/PostOffice.java
@@ -18,6 +18,7 @@ package com.echostreams.pulsar.mqtt.broker;
 import com.echostreams.pulsar.mqtt.broker.subscriptions.ISubscriptionsDirectory;
 import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
 import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import com.echostreams.pulsar.mqtt.broker.utils.NettyUtils;
 import com.echostreams.pulsar.mqtt.interception.BrokerInterceptor;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -30,7 +31,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.echostreams.pulsar.mqtt.broker.Utils.messageId;
+import static com.echostreams.pulsar.mqtt.broker.utils.Utils.messageId;
 import static io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader.from;
 import static io.netty.handler.codec.mqtt.MqttQoS.*;
 

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/PostOffice.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/PostOffice.java
@@ -176,7 +176,7 @@ class PostOffice {
         interceptor.notifyTopicPublished(msg, clientID, username);
     }
 
-    void receivedPublishQos1(MQTTConnection connection, Topic topic, String username, ByteBuf payload, int messageID,
+    void  receivedPublishQos1(MQTTConnection connection, Topic topic, String username, ByteBuf payload, int messageID,
                              boolean retain, MqttPublishMessage msg) {
         // verify if topic can be write
         topic.getTokens();

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/PostOffice.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/PostOffice.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.ISubscriptionsDirectory;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import com.echostreams.pulsar.mqtt.interception.BrokerInterceptor;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.echostreams.pulsar.mqtt.broker.Utils.messageId;
+import static io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader.from;
+import static io.netty.handler.codec.mqtt.MqttQoS.*;
+
+class PostOffice {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PostOffice.class);
+
+    private final Authorizator authorizator;
+    private final ISubscriptionsDirectory subscriptions;
+    private final IRetainedRepository retainedRepository;
+    private SessionRegistry sessionRegistry;
+    private BrokerInterceptor interceptor;
+
+    PostOffice(ISubscriptionsDirectory subscriptions, IRetainedRepository retainedRepository,
+               SessionRegistry sessionRegistry, BrokerInterceptor interceptor, Authorizator authorizator) {
+        this.authorizator = authorizator;
+        this.subscriptions = subscriptions;
+        this.retainedRepository = retainedRepository;
+        this.sessionRegistry = sessionRegistry;
+        this.interceptor = interceptor;
+    }
+
+    public void init(SessionRegistry sessionRegistry) {
+        this.sessionRegistry = sessionRegistry;
+    }
+
+    public void fireWill(Session.Will will) {
+        // MQTT 3.1.2.8-17
+        publish2Subscribers(will.payload, new Topic(will.topic), will.qos);
+    }
+
+    public void subscribeClientToTopics(MqttSubscribeMessage msg, String clientID, String username,
+                                        MQTTConnection mqttConnection) {
+        // verify which topics of the subscribe ongoing has read access permission
+        int messageID = messageId(msg);
+        List<MqttTopicSubscription> ackTopics = authorizator.verifyTopicsReadAccess(clientID, username, msg);
+        MqttSubAckMessage ackMessage = doAckMessageFromValidateFilters(ackTopics, messageID);
+
+        // store topics subscriptions in session
+        List<Subscription> newSubscriptions = ackTopics.stream()
+            .filter(req -> req.qualityOfService() != FAILURE)
+            .map(req -> {
+                final Topic topic = new Topic(req.topicName());
+                return new Subscription(clientID, topic, req.qualityOfService());
+            }).collect(Collectors.toList());
+
+        for (Subscription subscription : newSubscriptions) {
+            subscriptions.add(subscription);
+        }
+
+        // add the subscriptions to Session
+        Session session = sessionRegistry.retrieve(clientID);
+        session.addSubscriptions(newSubscriptions);
+
+        // send ack message
+        mqttConnection.sendSubAckMessage(messageID, ackMessage);
+
+        publishRetainedMessagesForSubscriptions(clientID, newSubscriptions);
+
+        for (Subscription subscription : newSubscriptions) {
+            interceptor.notifyTopicSubscribed(subscription, username);
+        }
+    }
+
+    private void publishRetainedMessagesForSubscriptions(String clientID, List<Subscription> newSubscriptions) {
+        Session targetSession = this.sessionRegistry.retrieve(clientID);
+        for (Subscription subscription : newSubscriptions) {
+            final String topicFilter = subscription.getTopicFilter().toString();
+            final List<RetainedMessage> retainedMsgs = retainedRepository.retainedOnTopic(topicFilter);
+
+            if (retainedMsgs.isEmpty()) {
+                // not found
+                continue;
+            }
+            for (RetainedMessage retainedMsg : retainedMsgs) {
+                final MqttQoS retainedQos = retainedMsg.qosLevel();
+                MqttQoS qos = lowerQosToTheSubscriptionDesired(subscription, retainedQos);
+
+//                final ByteBuf origPayload = retainedMsg.getPayload();
+                final ByteBuf payloadBuf = Unpooled.wrappedBuffer(retainedMsg.getPayload());
+//                ByteBuf payload = origPayload.retainedDuplicate();
+                targetSession.sendRetainedPublishOnSessionAtQos(subscription.getTopicFilter(), qos, payloadBuf);
+            }
+        }
+    }
+
+    /**
+     * Create the SUBACK response from a list of topicFilters
+     */
+    private MqttSubAckMessage doAckMessageFromValidateFilters(List<MqttTopicSubscription> topicFilters, int messageId) {
+        List<Integer> grantedQoSLevels = new ArrayList<>();
+        for (MqttTopicSubscription req : topicFilters) {
+            grantedQoSLevels.add(req.qualityOfService().value());
+        }
+
+        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.SUBACK, false, AT_MOST_ONCE,
+            false, 0);
+        MqttSubAckPayload payload = new MqttSubAckPayload(grantedQoSLevels);
+        return new MqttSubAckMessage(fixedHeader, from(messageId), payload);
+    }
+
+    public void unsubscribe(List<String> topics, MQTTConnection mqttConnection, int messageId) {
+        final String clientID = mqttConnection.getClientId();
+        for (String t : topics) {
+            Topic topic = new Topic(t);
+            boolean validTopic = topic.isValid();
+            if (!validTopic) {
+                // close the connection, not valid topicFilter is a protocol violation
+                mqttConnection.dropConnection();
+                LOG.warn("Topic filter is not valid. CId={}, topics: {}, offending topic filter: {}", clientID,
+                         topics, topic);
+                return;
+            }
+
+            LOG.trace("Removing subscription. CId={}, topic={}", clientID, topic);
+            subscriptions.removeSubscription(topic, clientID);
+
+            // TODO remove the subscriptions to Session
+//            clientSession.unsubscribeFrom(topic);
+
+            String username = NettyUtils.userName(mqttConnection.channel);
+            interceptor.notifyTopicUnsubscribed(topic.toString(), clientID, username);
+        }
+
+        // ack the client
+        mqttConnection.sendUnsubAckMessage(topics, clientID, messageId);
+    }
+
+    void receivedPublishQos0(Topic topic, String username, String clientID, ByteBuf payload, boolean retain,
+                             MqttPublishMessage msg) {
+        if (!authorizator.canWrite(topic, username, clientID)) {
+            LOG.error("MQTT client: {} is not authorized to publish on topic: {}", clientID, topic);
+            return;
+        }
+        publish2Subscribers(payload, topic, AT_MOST_ONCE);
+
+        if (retain) {
+            // QoS == 0 && retain => clean old retained
+            retainedRepository.cleanRetained(topic);
+        }
+
+        interceptor.notifyTopicPublished(msg, clientID, username);
+    }
+
+    void receivedPublishQos1(MQTTConnection connection, Topic topic, String username, ByteBuf payload, int messageID,
+                             boolean retain, MqttPublishMessage msg) {
+        // verify if topic can be write
+        topic.getTokens();
+        if (!topic.isValid()) {
+            LOG.warn("Invalid topic format, force close the connection");
+            connection.dropConnection();
+            return;
+        }
+        final String clientId = connection.getClientId();
+        if (!authorizator.canWrite(topic, username, clientId)) {
+            LOG.error("MQTT client: {} is not authorized to publish on topic: {}", clientId, topic);
+            return;
+        }
+
+        publish2Subscribers(payload, topic, AT_LEAST_ONCE);
+
+        connection.sendPubAck(messageID);
+
+        if (retain) {
+            if (!payload.isReadable()) {
+                retainedRepository.cleanRetained(topic);
+            } else {
+                // before wasn't stored
+                retainedRepository.retain(topic, msg);
+            }
+        }
+        interceptor.notifyTopicPublished(msg, clientId, username);
+    }
+
+    private void publish2Subscribers(ByteBuf origPayload, Topic topic, MqttQoS publishingQos) {
+        Set<Subscription> topicMatchingSubscriptions = subscriptions.matchQosSharpening(topic);
+
+        for (final Subscription sub : topicMatchingSubscriptions) {
+            MqttQoS qos = lowerQosToTheSubscriptionDesired(sub, publishingQos);
+            Session targetSession = this.sessionRegistry.retrieve(sub.getClientId());
+
+            boolean isSessionPresent = targetSession != null;
+            if (isSessionPresent) {
+                LOG.debug("Sending PUBLISH message to active subscriber CId: {}, topicFilter: {}, qos: {}",
+                          sub.getClientId(), sub.getTopicFilter(), qos);
+                // we need to retain because duplicate only copy r/w indexes and don't retain() causing refCnt = 0
+                ByteBuf payload = origPayload.retainedDuplicate();
+                targetSession.sendPublishOnSessionAtQos(topic, qos, payload);
+            } else {
+                // If we are, the subscriber disconnected after the subscriptions tree selected that session as a
+                // destination.
+                LOG.debug("PUBLISH to not yet present session. CId: {}, topicFilter: {}, qos: {}", sub.getClientId(),
+                          sub.getTopicFilter(), qos);
+            }
+        }
+    }
+
+    /**
+     * First phase of a publish QoS2 protocol, sent by publisher to the broker. Publish to all interested
+     * subscribers.
+     */
+    void receivedPublishQos2(MQTTConnection connection, MqttPublishMessage mqttPublishMessage, String username) {
+        LOG.trace("Processing PUBREL message on connection: {}", connection);
+        final Topic topic = new Topic(mqttPublishMessage.variableHeader().topicName());
+        final ByteBuf payload = mqttPublishMessage.payload();
+
+        final String clientId = connection.getClientId();
+        if (!authorizator.canWrite(topic, username, clientId)) {
+            LOG.error("MQTT client is not authorized to publish on topic. CId={}, topic: {}", clientId, topic);
+            return;
+        }
+
+        publish2Subscribers(payload, topic, EXACTLY_ONCE);
+
+        final boolean retained = mqttPublishMessage.fixedHeader().isRetain();
+        if (retained) {
+            if (!payload.isReadable()) {
+                retainedRepository.cleanRetained(topic);
+            } else {
+                // before wasn't stored
+                retainedRepository.retain(topic, mqttPublishMessage);
+            }
+        }
+
+        String clientID = connection.getClientId();
+        interceptor.notifyTopicPublished(mqttPublishMessage, clientID, username);
+    }
+
+    static MqttQoS lowerQosToTheSubscriptionDesired(Subscription sub, MqttQoS qos) {
+        if (qos.value() > sub.getRequestedQos().value()) {
+            qos = sub.getRequestedQos();
+        }
+        return qos;
+    }
+
+    /**
+     * Intended usage is only for embedded versions of the broker, where the hosting application
+     * want to use the broker to send a publish message. Like normal external publish message but
+     * with some changes to avoid security check, and the handshake phases for Qos1 and Qos2. It
+     * also doesn't notifyTopicPublished because using internally the owner should already know
+     * where it's publishing.
+     *
+     * @param msg
+     *            the message to publish
+     */
+    public void internalPublish(MqttPublishMessage msg) {
+        final MqttQoS qos = msg.fixedHeader().qosLevel();
+        final Topic topic = new Topic(msg.variableHeader().topicName());
+        final ByteBuf payload = msg.payload();
+        LOG.info("Sending internal PUBLISH message Topic={}, qos={}", topic, qos);
+
+        publish2Subscribers(payload, topic, qos);
+
+        if (!msg.fixedHeader().isRetain()) {
+            return;
+        }
+        if (qos == AT_MOST_ONCE || msg.payload().readableBytes() == 0) {
+            // QoS == 0 && retain => clean old retained
+            retainedRepository.cleanRetained(topic);
+            return;
+        }
+        retainedRepository.retain(topic, msg);
+    }
+
+    /**
+     * notify MqttConnectMessage after connection established (already pass login).
+     * @param msg
+     */
+    void dispatchConnection(MqttConnectMessage msg){
+        interceptor.notifyClientConnected(msg);
+    }
+
+    void dispatchDisconnection(String clientId,String userName){
+        interceptor.notifyClientDisconnected(clientId,userName);
+    }
+
+    void dispatchConnectionLost(String clientId,String userName){
+        interceptor.notifyClientConnectionLost(clientId,userName);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/PulsarConnect.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/PulsarConnect.java
@@ -1,0 +1,38 @@
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class PulsarConnect {
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarConnect.class);
+
+    public static PulsarConnect pulsarConnect;
+    public PulsarClient client;
+
+    public static synchronized PulsarConnect getPulsarCon() {
+        if (pulsarConnect == null) {
+            //synchronized block to remove overhead
+            synchronized (PulsarConnect.class) {
+                if (pulsarConnect == null) {
+                    // if instance is null, initialize
+                    pulsarConnect = new PulsarConnect();
+                }
+            }
+        }
+        return pulsarConnect;
+    }
+
+    private PulsarConnect() {
+        try {
+            client = PulsarClient.builder()
+                    .serviceUrl(BrokerConstants.PULSAR_SERVICE_URL)
+                    .build();
+        } catch (PulsarClientException e) {
+            LOG.error("Error occurred during pulsar client : {}", e);
+        }
+    }
+
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/RetainedMessage.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/RetainedMessage.java
@@ -1,0 +1,24 @@
+package com.echostreams.pulsar.mqtt.broker;
+
+import io.netty.handler.codec.mqtt.MqttQoS;
+
+import java.io.Serializable;
+
+public class RetainedMessage implements Serializable{
+
+    private final MqttQoS qos;
+    private final byte[] payload;
+
+    public RetainedMessage(MqttQoS qos, byte[] payload) {
+        this.qos = qos;
+        this.payload = payload;
+    }
+
+    public MqttQoS qosLevel() {
+        return qos;
+    }
+
+    public byte[] getPayload() {
+        return payload;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/Server.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/Server.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.config.*;
+import com.echostreams.pulsar.mqtt.broker.security.*;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.ISubscriptionsDirectory;
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.interception.InterceptHandler;
+import com.echostreams.pulsar.mqtt.persistence.H2Builder;
+import com.echostreams.pulsar.mqtt.persistence.MemorySubscriptionsRepository;
+import com.echostreams.pulsar.mqtt.interception.BrokerInterceptor;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.CTrieSubscriptionDirectory;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.text.ParseException;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.echostreams.pulsar.mqtt.logging.LoggingUtils.getInterceptorIds;
+
+public class Server {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Server.class);
+
+    private ScheduledExecutorService scheduler;
+    private NewNettyAcceptor acceptor;
+    private volatile boolean initialized;
+    private PostOffice dispatcher;
+    private BrokerInterceptor interceptor;
+    private H2Builder h2Builder;
+    private SessionRegistry sessions;
+
+    public static void main(String[] args) throws IOException {
+        final Server server = new Server();
+        server.startServer();
+        System.out.println("Server started, version 0.13-SNAPSHOT");
+        //Bind a shutdown hook
+        Runtime.getRuntime().addShutdownHook(new Thread(server::stopServer));
+    }
+
+    /**
+     * Starts Moquette bringing the configuration from the file located at m_config/moquette.conf
+     *
+     * @throws IOException in case of any IO error.
+     */
+    public void startServer() throws IOException {
+        File defaultConfigurationFile = defaultConfigFile();
+        LOG.info("Starting Moquette integration. Configuration file path={}", defaultConfigurationFile.getAbsolutePath());
+        IResourceLoader filesystemLoader = new FileResourceLoader(defaultConfigurationFile);
+        final IConfig config = new ResourceLoaderConfig(filesystemLoader);
+        startServer(config);
+    }
+
+    private static File defaultConfigFile() {
+        String configPath = System.getProperty("moquette.path", null);
+        return new File(configPath, IConfig.DEFAULT_CONFIG);
+    }
+
+    /**
+     * Starts Moquette bringing the configuration from the given file
+     *
+     * @param configFile text file that contains the configuration.
+     * @throws IOException in case of any IO Error.
+     */
+    public void startServer(File configFile) throws IOException {
+        LOG.info("Starting Moquette integration. Configuration file path: {}", configFile.getAbsolutePath());
+        IResourceLoader filesystemLoader = new FileResourceLoader(configFile);
+        final IConfig config = new ResourceLoaderConfig(filesystemLoader);
+        startServer(config);
+    }
+
+    /**
+     * Starts the integration with the given properties.
+     * <p>
+     * Its suggested to at least have the following properties:
+     * <ul>
+     *  <li>port</li>
+     *  <li>password_file</li>
+     * </ul>
+     *
+     * @param configProps the properties map to use as configuration.
+     * @throws IOException in case of any IO Error.
+     */
+    public void startServer(Properties configProps) throws IOException {
+        LOG.debug("Starting Moquette integration using properties object");
+        final IConfig config = new MemoryConfig(configProps);
+        startServer(config);
+    }
+
+    /**
+     * Starts Moquette bringing the configuration files from the given Config implementation.
+     *
+     * @param config the configuration to use to start the broker.
+     * @throws IOException in case of any IO Error.
+     */
+    public void startServer(IConfig config) throws IOException {
+        LOG.debug("Starting Moquette integration using IConfig instance");
+        startServer(config, null);
+    }
+
+    /**
+     * Starts Moquette with config provided by an implementation of IConfig class and with the set
+     * of InterceptHandler.
+     *
+     * @param config   the configuration to use to start the broker.
+     * @param handlers the handlers to install in the broker.
+     * @throws IOException in case of any IO Error.
+     */
+    public void startServer(IConfig config, List<? extends InterceptHandler> handlers) throws IOException {
+        LOG.debug("Starting moquette integration using IConfig instance and intercept handlers");
+        startServer(config, handlers, null, null, null);
+    }
+
+    public void startServer(IConfig config, List<? extends InterceptHandler> handlers, ISslContextCreator sslCtxCreator,
+                            IAuthenticator authenticator, IAuthorizatorPolicy authorizatorPolicy) {
+        final long start = System.currentTimeMillis();
+        if (handlers == null) {
+            handlers = Collections.emptyList();
+        }
+        LOG.trace("Starting Moquette Server. MQTT message interceptors={}", getInterceptorIds(handlers));
+
+        scheduler = Executors.newScheduledThreadPool(1);
+
+        final String handlerProp = System.getProperty(BrokerConstants.INTERCEPT_HANDLER_PROPERTY_NAME);
+        if (handlerProp != null) {
+            config.setProperty(BrokerConstants.INTERCEPT_HANDLER_PROPERTY_NAME, handlerProp);
+        }
+        final String persistencePath = config.getProperty(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME);
+        LOG.debug("Configuring Using persistent store file, path: {}", persistencePath);
+        initInterceptors(config, handlers);
+        LOG.debug("Initialized MQTT protocol processor");
+        if (sslCtxCreator == null) {
+            LOG.info("Using default SSL context creator");
+            sslCtxCreator = new DefaultMoquetteSslContextCreator(config);
+        }
+        authenticator = initializeAuthenticator(authenticator, config);
+        authorizatorPolicy = initializeAuthorizatorPolicy(authorizatorPolicy, config);
+
+        final ISubscriptionsRepository subscriptionsRepository;
+        final IQueueRepository queueRepository;
+        final IRetainedRepository retainedRepository;
+        if (persistencePath != null && !persistencePath.isEmpty()) {
+            LOG.trace("Configuring H2 subscriptions store to {}", persistencePath);
+            h2Builder = new H2Builder(config, scheduler).initStore();
+            subscriptionsRepository = h2Builder.subscriptionsRepository();
+            queueRepository = h2Builder.queueRepository();
+            retainedRepository = h2Builder.retainedRepository();
+        } else {
+            LOG.trace("Configuring in-memory subscriptions store");
+            subscriptionsRepository = new MemorySubscriptionsRepository();
+            queueRepository = new MemoryQueueRepository();
+            retainedRepository = new MemoryRetainedRepository();
+        }
+
+        ISubscriptionsDirectory subscriptions = new CTrieSubscriptionDirectory();
+        subscriptions.init(subscriptionsRepository);
+        final Authorizator authorizator = new Authorizator(authorizatorPolicy);
+        sessions = new SessionRegistry(subscriptions, queueRepository, authorizator);
+        dispatcher = new PostOffice(subscriptions, retainedRepository, sessions, interceptor, authorizator);
+        final BrokerConfiguration brokerConfig = new BrokerConfiguration(config);
+        MQTTConnectionFactory connectionFactory = new MQTTConnectionFactory(brokerConfig, authenticator, sessions,
+                                                                            dispatcher);
+
+        final NewNettyMQTTHandler mqttHandler = new NewNettyMQTTHandler(connectionFactory);
+        acceptor = new NewNettyAcceptor();
+        acceptor.initialize(mqttHandler, config, sslCtxCreator);
+
+        final long startTime = System.currentTimeMillis() - start;
+        LOG.info("Moquette integration has been started successfully in {} ms", startTime);
+        initialized = true;
+    }
+
+    private IAuthorizatorPolicy initializeAuthorizatorPolicy(IAuthorizatorPolicy authorizatorPolicy, IConfig props) {
+        LOG.debug("Configuring MQTT authorizator policy");
+        String authorizatorClassName = props.getProperty(BrokerConstants.AUTHORIZATOR_CLASS_NAME, "");
+        if (authorizatorPolicy == null && !authorizatorClassName.isEmpty()) {
+            authorizatorPolicy = loadClass(authorizatorClassName, IAuthorizatorPolicy.class, IConfig.class, props);
+        }
+
+        if (authorizatorPolicy == null) {
+            String aclFilePath = props.getProperty(BrokerConstants.ACL_FILE_PROPERTY_NAME, "");
+            if (aclFilePath != null && !aclFilePath.isEmpty()) {
+                authorizatorPolicy = new DenyAllAuthorizatorPolicy();
+                try {
+                    LOG.info("Parsing ACL file. Path = {}", aclFilePath);
+                    IResourceLoader resourceLoader = props.getResourceLoader();
+                    authorizatorPolicy = ACLFileParser.parse(resourceLoader.loadResource(aclFilePath));
+                } catch (ParseException pex) {
+                    LOG.error("Unable to parse ACL file. path = {}", aclFilePath, pex);
+                }
+            } else {
+                authorizatorPolicy = new PermitAllAuthorizatorPolicy();
+            }
+            LOG.info("Authorizator policy {} instance will be used", authorizatorPolicy.getClass().getName());
+        }
+        return authorizatorPolicy;
+    }
+
+    private IAuthenticator initializeAuthenticator(IAuthenticator authenticator, IConfig props) {
+        LOG.debug("Configuring MQTT authenticator");
+        String authenticatorClassName = props.getProperty(BrokerConstants.AUTHENTICATOR_CLASS_NAME, "");
+
+        if (authenticator == null && !authenticatorClassName.isEmpty()) {
+            authenticator = loadClass(authenticatorClassName, IAuthenticator.class, IConfig.class, props);
+        }
+
+        IResourceLoader resourceLoader = props.getResourceLoader();
+        if (authenticator == null) {
+            String passwdPath = props.getProperty(BrokerConstants.PASSWORD_FILE_PROPERTY_NAME, "");
+            if (passwdPath.isEmpty()) {
+                authenticator = new AcceptAllAuthenticator();
+            } else {
+                authenticator = new ResourceAuthenticator(resourceLoader, passwdPath);
+            }
+            LOG.info("An {} authenticator instance will be used", authenticator.getClass().getName());
+        }
+        return authenticator;
+    }
+
+    private void initInterceptors(IConfig props, List<? extends InterceptHandler> embeddedObservers) {
+        LOG.info("Configuring message interceptors...");
+
+        List<InterceptHandler> observers = new ArrayList<>(embeddedObservers);
+        String interceptorClassName = props.getProperty(BrokerConstants.INTERCEPT_HANDLER_PROPERTY_NAME);
+        if (interceptorClassName != null && !interceptorClassName.isEmpty()) {
+            InterceptHandler handler = loadClass(interceptorClassName, InterceptHandler.class,
+                                                 Server.class, this);
+            if (handler != null) {
+                observers.add(handler);
+            }
+        }
+        interceptor = new BrokerInterceptor(props, observers);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T, U> T loadClass(String className, Class<T> intrface, Class<U> constructorArgClass, U props) {
+        T instance = null;
+        try {
+            // check if constructor with constructor arg class parameter
+            // exists
+            LOG.info("Invoking constructor with {} argument. ClassName={}, interfaceName={}",
+                     constructorArgClass.getName(), className, intrface.getName());
+            instance = this.getClass().getClassLoader()
+                .loadClass(className)
+                .asSubclass(intrface)
+                .getConstructor(constructorArgClass)
+                .newInstance(props);
+        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException ex) {
+            LOG.warn("Unable to invoke constructor with {} argument. ClassName={}, interfaceName={}, cause={}, " +
+                     "errorMessage={}", constructorArgClass.getName(), className, intrface.getName(), ex.getCause(),
+                     ex.getMessage());
+            return null;
+        } catch (NoSuchMethodException | InvocationTargetException e) {
+            try {
+                LOG.info("Invoking default constructor. ClassName={}, interfaceName={}", className, intrface.getName());
+                // fallback to default constructor
+                instance = this.getClass().getClassLoader()
+                    .loadClass(className)
+                    .asSubclass(intrface)
+                    .getDeclaredConstructor().newInstance();
+            } catch (InstantiationException | IllegalAccessException | ClassNotFoundException |
+                NoSuchMethodException | InvocationTargetException ex) {
+                LOG.error("Unable to invoke default constructor. ClassName={}, interfaceName={}, cause={}, " +
+                          "errorMessage={}", className, intrface.getName(), ex.getCause(), ex.getMessage());
+                return null;
+            }
+        }
+
+        return instance;
+    }
+
+    /**
+     * Use the broker to publish a message. It's intended for embedding applications. It can be used
+     * only after the integration is correctly started with startServer.
+     *
+     * @param msg      the message to forward.
+     * @param clientId the id of the sending integration.
+     * @throws IllegalStateException if the integration is not yet started
+     */
+    public void internalPublish(MqttPublishMessage msg, final String clientId) {
+        final int messageID = msg.variableHeader().packetId();
+        if (!initialized) {
+            LOG.error("Moquette is not started, internal message cannot be published. CId: {}, messageId: {}", clientId,
+                      messageID);
+            throw new IllegalStateException("Can't publish on a integration is not yet started");
+        }
+        LOG.trace("Internal publishing message CId: {}, messageId: {}", clientId, messageID);
+        dispatcher.internalPublish(msg);
+    }
+
+    public void stopServer() {
+        LOG.info("Unbinding integration from the configured ports");
+        acceptor.close();
+        LOG.trace("Stopping MQTT protocol processor");
+        initialized = false;
+
+        // calling shutdown() does not actually stop tasks that are not cancelled,
+        // and SessionsRepository does not stop its tasks. Thus shutdownNow().
+        scheduler.shutdownNow();
+
+        if (h2Builder != null) {
+            LOG.trace("Shutting down H2 persistence {}");
+            h2Builder.closeStore();
+        }
+
+        LOG.info("Moquette integration has been stopped.");
+    }
+
+    public int getPort() {
+        return acceptor.getPort();
+    }
+
+    public int getSslPort() {
+        return acceptor.getSslPort();
+    }
+
+    /**
+     * SPI method used by Broker embedded applications to get list of subscribers. Returns null if
+     * the broker is not started.
+     *
+     * @return list of subscriptions.
+     */
+// TODO reimplement this
+//    public List<Subscription> getSubscriptions() {
+//        if (m_processorBootstrapper == null) {
+//            return null;
+//        }
+//        return this.subscriptionsStore.listAllSubscriptions();
+//    }
+
+    /**
+     * SPI method used by Broker embedded applications to add intercept handlers.
+     *
+     * @param interceptHandler the handler to add.
+     */
+    public void addInterceptHandler(InterceptHandler interceptHandler) {
+        if (!initialized) {
+            LOG.error("Moquette is not started, MQTT message interceptor cannot be added. InterceptorId={}",
+                interceptHandler.getID());
+            throw new IllegalStateException("Can't register interceptors on a integration that is not yet started");
+        }
+        LOG.info("Adding MQTT message interceptor. InterceptorId={}", interceptHandler.getID());
+        interceptor.addInterceptHandler(interceptHandler);
+    }
+
+    /**
+     * SPI method used by Broker embedded applications to remove intercept handlers.
+     *
+     * @param interceptHandler the handler to remove.
+     */
+    public void removeInterceptHandler(InterceptHandler interceptHandler) {
+        if (!initialized) {
+            LOG.error("Moquette is not started, MQTT message interceptor cannot be removed. InterceptorId={}",
+                interceptHandler.getID());
+            throw new IllegalStateException("Can't deregister interceptors from a integration that is not yet started");
+        }
+        LOG.info("Removing MQTT message interceptor. InterceptorId={}", interceptHandler.getID());
+        interceptor.removeInterceptHandler(interceptHandler);
+    }
+
+    /**
+     * Return a list of descriptors of connected clients.
+     * */
+    public Collection<ClientDescriptor> listConnectedClients() {
+        return sessions.listConnectedClients();
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/Server.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/Server.java
@@ -66,8 +66,8 @@ public class Server {
     public void startServer() throws IOException {
         File defaultConfigurationFile = defaultConfigFile();
         LOG.info("Starting Moquette integration. Configuration file path={}", defaultConfigurationFile.getAbsolutePath());
-        IResourceLoader filesystemLoader = new FileResourceLoader(defaultConfigurationFile);
-        final IConfig config = new ResourceLoaderConfig(filesystemLoader);
+        IResourceLoader classpathResourceLoader = new ClasspathResourceLoader();
+        final IConfig config = new ResourceLoaderConfig(classpathResourceLoader);
         startServer(config);
     }
 
@@ -94,8 +94,8 @@ public class Server {
      * <p>
      * Its suggested to at least have the following properties:
      * <ul>
-     *  <li>port</li>
-     *  <li>password_file</li>
+     * <li>port</li>
+     * <li>password_file</li>
      * </ul>
      *
      * @param configProps the properties map to use as configuration.
@@ -179,14 +179,14 @@ public class Server {
         dispatcher = new PostOffice(subscriptions, retainedRepository, sessions, interceptor, authorizator);
         final BrokerConfiguration brokerConfig = new BrokerConfiguration(config);
         MQTTConnectionFactory connectionFactory = new MQTTConnectionFactory(brokerConfig, authenticator, sessions,
-                                                                            dispatcher);
+                dispatcher);
 
         final NewNettyMQTTHandler mqttHandler = new NewNettyMQTTHandler(connectionFactory);
         acceptor = new NewNettyAcceptor();
         acceptor.initialize(mqttHandler, config, sslCtxCreator);
 
         final long startTime = System.currentTimeMillis() - start;
-        LOG.info("Moquette integration has been started successfully in {} ms", startTime);
+        LOG.info("Moquette integration has been started successfully on in {} ms", startTime);
         initialized = true;
     }
 
@@ -244,7 +244,7 @@ public class Server {
         String interceptorClassName = props.getProperty(BrokerConstants.INTERCEPT_HANDLER_PROPERTY_NAME);
         if (interceptorClassName != null && !interceptorClassName.isEmpty()) {
             InterceptHandler handler = loadClass(interceptorClassName, InterceptHandler.class,
-                                                 Server.class, this);
+                    Server.class, this);
             if (handler != null) {
                 observers.add(handler);
             }
@@ -259,29 +259,29 @@ public class Server {
             // check if constructor with constructor arg class parameter
             // exists
             LOG.info("Invoking constructor with {} argument. ClassName={}, interfaceName={}",
-                     constructorArgClass.getName(), className, intrface.getName());
+                    constructorArgClass.getName(), className, intrface.getName());
             instance = this.getClass().getClassLoader()
-                .loadClass(className)
-                .asSubclass(intrface)
-                .getConstructor(constructorArgClass)
-                .newInstance(props);
+                    .loadClass(className)
+                    .asSubclass(intrface)
+                    .getConstructor(constructorArgClass)
+                    .newInstance(props);
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException ex) {
             LOG.warn("Unable to invoke constructor with {} argument. ClassName={}, interfaceName={}, cause={}, " +
-                     "errorMessage={}", constructorArgClass.getName(), className, intrface.getName(), ex.getCause(),
-                     ex.getMessage());
+                            "errorMessage={}", constructorArgClass.getName(), className, intrface.getName(), ex.getCause(),
+                    ex.getMessage());
             return null;
         } catch (NoSuchMethodException | InvocationTargetException e) {
             try {
                 LOG.info("Invoking default constructor. ClassName={}, interfaceName={}", className, intrface.getName());
                 // fallback to default constructor
                 instance = this.getClass().getClassLoader()
-                    .loadClass(className)
-                    .asSubclass(intrface)
-                    .getDeclaredConstructor().newInstance();
+                        .loadClass(className)
+                        .asSubclass(intrface)
+                        .getDeclaredConstructor().newInstance();
             } catch (InstantiationException | IllegalAccessException | ClassNotFoundException |
-                NoSuchMethodException | InvocationTargetException ex) {
+                    NoSuchMethodException | InvocationTargetException ex) {
                 LOG.error("Unable to invoke default constructor. ClassName={}, interfaceName={}, cause={}, " +
-                          "errorMessage={}", className, intrface.getName(), ex.getCause(), ex.getMessage());
+                        "errorMessage={}", className, intrface.getName(), ex.getCause(), ex.getMessage());
                 return null;
             }
         }
@@ -301,7 +301,7 @@ public class Server {
         final int messageID = msg.variableHeader().packetId();
         if (!initialized) {
             LOG.error("Moquette is not started, internal message cannot be published. CId: {}, messageId: {}", clientId,
-                      messageID);
+                    messageID);
             throw new IllegalStateException("Can't publish on a integration is not yet started");
         }
         LOG.trace("Internal publishing message CId: {}, messageId: {}", clientId, messageID);
@@ -356,7 +356,7 @@ public class Server {
     public void addInterceptHandler(InterceptHandler interceptHandler) {
         if (!initialized) {
             LOG.error("Moquette is not started, MQTT message interceptor cannot be added. InterceptorId={}",
-                interceptHandler.getID());
+                    interceptHandler.getID());
             throw new IllegalStateException("Can't register interceptors on a integration that is not yet started");
         }
         LOG.info("Adding MQTT message interceptor. InterceptorId={}", interceptHandler.getID());
@@ -371,7 +371,7 @@ public class Server {
     public void removeInterceptHandler(InterceptHandler interceptHandler) {
         if (!initialized) {
             LOG.error("Moquette is not started, MQTT message interceptor cannot be removed. InterceptorId={}",
-                interceptHandler.getID());
+                    interceptHandler.getID());
             throw new IllegalStateException("Can't deregister interceptors from a integration that is not yet started");
         }
         LOG.info("Removing MQTT message interceptor. InterceptorId={}", interceptHandler.getID());
@@ -380,7 +380,7 @@ public class Server {
 
     /**
      * Return a list of descriptors of connected clients.
-     * */
+     */
     public Collection<ClientDescriptor> listConnectedClients() {
         return sessions.listConnectedClients();
     }

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/Session.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/Session.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.mqtt.*;
+import io.netty.util.ReferenceCountUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.*;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+class Session {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Session.class);
+    private static final int FLIGHT_BEFORE_RESEND_MS = 5_000;
+    private static final int INFLIGHT_WINDOW_SIZE = 10;
+
+    static class InFlightPacket implements Delayed {
+
+        final int packetId;
+        private long startTime;
+
+        InFlightPacket(int packetId, long delayInMilliseconds) {
+            this.packetId = packetId;
+            this.startTime = System.currentTimeMillis() + delayInMilliseconds;
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            long diff = startTime - System.currentTimeMillis();
+            return unit.convert(diff, TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public int compareTo(Delayed o) {
+            if ((this.startTime - ((InFlightPacket) o).startTime) == 0) {
+                return 0;
+            }
+            if ((this.startTime - ((InFlightPacket) o).startTime) > 0) {
+                return 1;
+            } else {
+                return -1;
+            }
+        }
+    }
+
+    enum SessionStatus {
+        CONNECTED, CONNECTING, DISCONNECTING, DISCONNECTED
+    }
+
+    static final class Will {
+
+        final String topic;
+        final ByteBuf payload;
+        final MqttQoS qos;
+        final boolean retained;
+
+        Will(String topic, ByteBuf payload, MqttQoS qos, boolean retained) {
+            this.topic = topic;
+            this.payload = payload;
+            this.qos = qos;
+            this.retained = retained;
+        }
+    }
+
+    private final String clientId;
+    private boolean clean;
+    private Will will;
+    private Queue<SessionRegistry.EnqueuedMessage> sessionQueue;
+    private final AtomicReference<SessionStatus> status = new AtomicReference<>(SessionStatus.DISCONNECTED);
+    private MQTTConnection mqttConnection;
+    private List<Subscription> subscriptions = new ArrayList<>();
+    private final Map<Integer, SessionRegistry.EnqueuedMessage> inflightWindow = new HashMap<>();
+    private final DelayQueue<InFlightPacket> inflightTimeouts = new DelayQueue<>();
+    private final Map<Integer, MqttPublishMessage> qos2Receiving = new HashMap<>();
+    private final AtomicInteger inflightSlots = new AtomicInteger(INFLIGHT_WINDOW_SIZE); // this should be configurable
+
+    Session(String clientId, boolean clean, Will will, Queue<SessionRegistry.EnqueuedMessage> sessionQueue) {
+        this(clientId, clean, sessionQueue);
+        this.will = will;
+    }
+
+    Session(String clientId, boolean clean, Queue<SessionRegistry.EnqueuedMessage> sessionQueue) {
+        this.clientId = clientId;
+        this.clean = clean;
+        this.sessionQueue = sessionQueue;
+    }
+
+    void update(boolean clean, Will will) {
+        this.clean = clean;
+        this.will = will;
+    }
+
+    void markConnected() {
+        assignState(SessionStatus.DISCONNECTED, SessionStatus.CONNECTED);
+    }
+
+    void bind(MQTTConnection mqttConnection) {
+        this.mqttConnection = mqttConnection;
+    }
+
+    public boolean disconnected() {
+        return status.get() == SessionStatus.DISCONNECTED;
+    }
+
+    public boolean connected() {
+        return status.get() == SessionStatus.CONNECTED;
+    }
+
+    public String getClientID() {
+        return clientId;
+    }
+
+    public List<Subscription> getSubscriptions() {
+        return new ArrayList<>(subscriptions);
+    }
+
+    public void addSubscriptions(List<Subscription> newSubscriptions) {
+        subscriptions.addAll(newSubscriptions);
+    }
+
+    public boolean hasWill() {
+        return will != null;
+    }
+
+    public Will getWill() {
+        return will;
+    }
+
+    boolean assignState(SessionStatus expected, SessionStatus newState) {
+        return status.compareAndSet(expected, newState);
+    }
+
+    public void closeImmediately() {
+        mqttConnection.dropConnection();
+    }
+
+    public void disconnect() {
+        final boolean res = assignState(SessionStatus.CONNECTED, SessionStatus.DISCONNECTING);
+        if (!res) {
+            // someone already moved away from CONNECTED
+            // TODO what to do?
+            return;
+        }
+
+        mqttConnection = null;
+        will = null;
+
+        assignState(SessionStatus.DISCONNECTING, SessionStatus.DISCONNECTED);
+    }
+
+    boolean isClean() {
+        return clean;
+    }
+
+    public void processPubRec(int packetId) {
+        inflightWindow.remove(packetId);
+        inflightSlots.incrementAndGet();
+        if (canSkipQueue()) {
+            inflightSlots.decrementAndGet();
+            int pubRelPacketId = packetId/*mqttConnection.nextPacketId()*/;
+            inflightWindow.put(pubRelPacketId, new SessionRegistry.PubRelMarker());
+            inflightTimeouts.add(new InFlightPacket(pubRelPacketId, FLIGHT_BEFORE_RESEND_MS));
+            MqttMessage pubRel = MQTTConnection.pubrel(pubRelPacketId);
+            mqttConnection.sendIfWritableElseDrop(pubRel);
+
+            drainQueueToConnection();
+        } else {
+            sessionQueue.add(new SessionRegistry.PubRelMarker());
+        }
+    }
+
+    public void processPubComp(int messageID) {
+        inflightWindow.remove(messageID);
+        inflightSlots.incrementAndGet();
+
+        drainQueueToConnection();
+
+        // TODO notify the interceptor
+//                final InterceptAcknowledgedMessage interceptAckMsg = new InterceptAcknowledgedMessage(inflightMsg,
+// topic, username, messageID);
+//                m_interceptor.notifyMessageAcknowledged(interceptAckMsg);
+    }
+
+    public void sendPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload) {
+        switch (qos) {
+            case AT_MOST_ONCE:
+                if (connected()) {
+                    mqttConnection.sendPublishNotRetainedQos0(topic, qos, payload);
+                }
+                break;
+            case AT_LEAST_ONCE:
+                sendPublishQos1(topic, qos, payload);
+                break;
+            case EXACTLY_ONCE:
+                sendPublishQos2(topic, qos, payload);
+                break;
+            case FAILURE:
+                LOG.error("Not admissible");
+        }
+    }
+
+    private void sendPublishQos1(Topic topic, MqttQoS qos, ByteBuf payload) {
+        if (!connected() && isClean()) {
+            //pushing messages to disconnected not clean session
+            return;
+        }
+
+        if (canSkipQueue()) {
+            inflightSlots.decrementAndGet();
+            int packetId = mqttConnection.nextPacketId();
+            inflightWindow.put(packetId, new SessionRegistry.PublishedMessage(topic, qos, payload));
+            inflightTimeouts.add(new InFlightPacket(packetId, FLIGHT_BEFORE_RESEND_MS));
+            MqttPublishMessage publishMsg = MQTTConnection.notRetainedPublishWithMessageId(topic.toString(), qos,
+                                                                                           payload, packetId);
+            mqttConnection.sendPublish(publishMsg);
+
+            // TODO drainQueueToConnection();?
+        } else {
+            final SessionRegistry.PublishedMessage msg = new SessionRegistry.PublishedMessage(topic, qos, payload);
+            sessionQueue.add(msg);
+        }
+    }
+
+    private void sendPublishQos2(Topic topic, MqttQoS qos, ByteBuf payload) {
+        if (canSkipQueue()) {
+            inflightSlots.decrementAndGet();
+            int packetId = mqttConnection.nextPacketId();
+            inflightWindow.put(packetId, new SessionRegistry.PublishedMessage(topic, qos, payload));
+            inflightTimeouts.add(new InFlightPacket(packetId, FLIGHT_BEFORE_RESEND_MS));
+            MqttPublishMessage publishMsg = MQTTConnection.notRetainedPublishWithMessageId(topic.toString(), qos,
+                                                                                           payload, packetId);
+            mqttConnection.sendPublish(publishMsg);
+
+            drainQueueToConnection();
+        } else {
+            final SessionRegistry.PublishedMessage msg = new SessionRegistry.PublishedMessage(topic, qos, payload);
+            sessionQueue.add(msg);
+        }
+    }
+
+    private boolean canSkipQueue() {
+        return sessionQueue.isEmpty() &&
+            inflightSlots.get() > 0 &&
+            connected() &&
+            mqttConnection.channel.isWritable();
+    }
+
+    private boolean inflighHasSlotsAndConnectionIsUp() {
+        return inflightSlots.get() > 0 &&
+            connected() &&
+            mqttConnection.channel.isWritable();
+    }
+
+    void pubAckReceived(int ackPacketId) {
+        // TODO remain to invoke in somehow m_interceptor.notifyMessageAcknowledged
+        inflightWindow.remove(ackPacketId);
+        inflightSlots.incrementAndGet();
+        drainQueueToConnection();
+    }
+
+    public void resendInflightNotAcked() {
+        Collection<InFlightPacket> expired = new ArrayList<>(INFLIGHT_WINDOW_SIZE);
+        inflightTimeouts.drainTo(expired);
+
+        debugLogPacketIds(expired);
+
+        for (InFlightPacket notAckPacketId : expired) {
+            if (inflightWindow.containsKey(notAckPacketId.packetId)) {
+                final SessionRegistry.PublishedMessage msg =
+                    (SessionRegistry.PublishedMessage) inflightWindow.get(notAckPacketId.packetId);
+                final Topic topic = msg.topic;
+                final MqttQoS qos = msg.publishingQos;
+                final ByteBuf payload = msg.payload;
+                final ByteBuf copiedPayload = payload.retainedDuplicate();
+                MqttPublishMessage publishMsg = publishNotRetainedDuplicated(notAckPacketId, topic, qos, copiedPayload);
+                mqttConnection.sendPublish(publishMsg);
+            }
+        }
+    }
+
+    private void debugLogPacketIds(Collection<InFlightPacket> expired) {
+        if (!LOG.isDebugEnabled() || expired.isEmpty()) {
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (InFlightPacket packet : expired) {
+            sb.append(packet.packetId).append(", ");
+        }
+        LOG.debug("Resending {} in flight packets [{}]", expired.size(), sb);
+    }
+
+    private MqttPublishMessage publishNotRetainedDuplicated(InFlightPacket notAckPacketId, Topic topic, MqttQoS qos,
+                                                            ByteBuf payload) {
+        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, true, qos, false, 0);
+        MqttPublishVariableHeader varHeader = new MqttPublishVariableHeader(topic.toString(), notAckPacketId.packetId);
+        return new MqttPublishMessage(fixedHeader, varHeader, payload);
+    }
+
+    private void drainQueueToConnection() {
+        // consume the queue
+        while (!sessionQueue.isEmpty() && inflighHasSlotsAndConnectionIsUp()) {
+            final SessionRegistry.EnqueuedMessage msg = sessionQueue.remove();
+            inflightSlots.decrementAndGet();
+            int sendPacketId = mqttConnection.nextPacketId();
+            inflightWindow.put(sendPacketId, msg);
+            if (msg instanceof SessionRegistry.PubRelMarker) {
+                MqttMessage pubRel = MQTTConnection.pubrel(sendPacketId);
+                mqttConnection.sendIfWritableElseDrop(pubRel);
+            } else {
+                final SessionRegistry.PublishedMessage msgPub = (SessionRegistry.PublishedMessage) msg;
+                MqttPublishMessage publishMsg = MQTTConnection.notRetainedPublishWithMessageId(msgPub.topic.toString(),
+                    msgPub.publishingQos,
+                    msgPub.payload, sendPacketId);
+                mqttConnection.sendPublish(publishMsg);
+            }
+        }
+    }
+
+    public void writabilityChanged() {
+        drainQueueToConnection();
+    }
+
+    public void sendQueuedMessagesWhileOffline() {
+        LOG.trace("Republishing all saved messages for session {} on CId={}", this, this.clientId);
+        drainQueueToConnection();
+    }
+
+    void sendRetainedPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload) {
+        if (qos != MqttQoS.AT_MOST_ONCE) {
+            // QoS 1 or 2
+            mqttConnection.sendPublishRetainedWithPacketId(topic, qos, payload);
+        } else {
+            mqttConnection.sendPublishRetainedQos0(topic, qos, payload);
+        }
+    }
+
+    public void receivedPublishQos2(int messageID, MqttPublishMessage msg) {
+        qos2Receiving.put(messageID, msg);
+        msg.retain(); // retain to put in the inflight map
+        mqttConnection.sendPublishReceived(messageID);
+    }
+
+    public void receivedPubRelQos2(int messageID) {
+        final MqttPublishMessage removedMsg = qos2Receiving.remove(messageID);
+        ReferenceCountUtil.release(removedMsg);
+    }
+
+    Optional<InetSocketAddress> remoteAddress() {
+        if (connected()) {
+            return Optional.of(mqttConnection.remoteAddress());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String toString() {
+        return "Session{" +
+            "clientId='" + clientId + '\'' +
+            ", clean=" + clean +
+            ", status=" + status +
+            ", inflightSlots=" + inflightSlots +
+            '}';
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/SessionCorruptedException.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/SessionCorruptedException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+public class SessionCorruptedException extends RuntimeException {
+
+    private static final long serialVersionUID = 5848069213104389412L;
+
+    SessionCorruptedException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/SessionRegistry.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/SessionRegistry.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.ISubscriptionsDirectory;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+public class SessionRegistry {
+
+    public abstract static class EnqueuedMessage {
+    }
+
+    static class PublishedMessage extends EnqueuedMessage {
+
+        final Topic topic;
+        final MqttQoS publishingQos;
+        final ByteBuf payload;
+
+        PublishedMessage(Topic topic, MqttQoS publishingQos, ByteBuf payload) {
+            this.topic = topic;
+            this.publishingQos = publishingQos;
+            this.payload = payload;
+        }
+    }
+
+    static final class PubRelMarker extends EnqueuedMessage {
+    }
+
+    private enum PostConnectAction {
+        NONE, SEND_STORED_MESSAGES
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(SessionRegistry.class);
+
+    private final ConcurrentMap<String, Session> pool = new ConcurrentHashMap<>();
+    private final ISubscriptionsDirectory subscriptionsDirectory;
+    private final IQueueRepository queueRepository;
+    private final Authorizator authorizator;
+    private final ConcurrentMap<String, Queue<SessionRegistry.EnqueuedMessage>> queues = new ConcurrentHashMap<>();
+
+    SessionRegistry(ISubscriptionsDirectory subscriptionsDirectory,
+                    IQueueRepository queueRepository,
+                    Authorizator authorizator) {
+        this.subscriptionsDirectory = subscriptionsDirectory;
+        this.queueRepository = queueRepository;
+        this.authorizator = authorizator;
+    }
+
+    void bindToSession(MQTTConnection mqttConnection, MqttConnectMessage msg, String clientId) {
+        boolean isSessionAlreadyStored = false;
+        PostConnectAction postConnectAction = PostConnectAction.NONE;
+        if (!pool.containsKey(clientId)) {
+            // case 1
+            final Session newSession = createNewSession(mqttConnection, msg, clientId);
+
+            // publish the session
+            final Session previous = pool.putIfAbsent(clientId, newSession);
+            final boolean success = previous == null;
+
+            if (success) {
+                LOG.trace("case 1, not existing session with CId {}", clientId);
+            } else {
+                postConnectAction = bindToExistingSession(mqttConnection, msg, clientId, newSession);
+                isSessionAlreadyStored = true;
+            }
+        } else {
+            final Session newSession = createNewSession(mqttConnection, msg, clientId);
+            postConnectAction = bindToExistingSession(mqttConnection, msg, clientId, newSession);
+            isSessionAlreadyStored = true;
+        }
+        final boolean msgCleanSessionFlag = msg.variableHeader().isCleanSession();
+        boolean isSessionAlreadyPresent = !msgCleanSessionFlag && isSessionAlreadyStored;
+        mqttConnection.sendConnAck(isSessionAlreadyPresent);
+
+        if (postConnectAction == PostConnectAction.SEND_STORED_MESSAGES) {
+            final Session session = pool.get(clientId);
+            session.sendQueuedMessagesWhileOffline();
+        }
+    }
+
+    private PostConnectAction bindToExistingSession(MQTTConnection mqttConnection, MqttConnectMessage msg,
+                                                    String clientId, Session newSession) {
+        PostConnectAction postConnectAction = PostConnectAction.NONE;
+        final boolean newIsClean = msg.variableHeader().isCleanSession();
+        final Session oldSession = pool.get(clientId);
+        if (newIsClean && oldSession.disconnected()) {
+            // case 2
+            dropQueuesForClient(clientId);
+            unsubscribe(oldSession);
+
+            // publish new session
+            boolean result = oldSession.assignState(Session.SessionStatus.DISCONNECTED, Session.SessionStatus.CONNECTING);
+            if (!result) {
+                throw new SessionCorruptedException("old session was already changed state");
+            }
+            copySessionConfig(msg, oldSession);
+            oldSession.bind(mqttConnection);
+
+            result = oldSession.assignState(Session.SessionStatus.CONNECTING, Session.SessionStatus.CONNECTED);
+            if (!result) {
+                throw new SessionCorruptedException("old session moved in connected state by other thread");
+            }
+            final boolean published = pool.replace(clientId, oldSession, oldSession);
+            if (!published) {
+                throw new SessionCorruptedException("old session was already removed");
+            }
+            LOG.trace("case 2, oldSession with same CId {} disconnected", clientId);
+        } else if (!newIsClean && oldSession.disconnected()) {
+            // case 3
+            final String username = mqttConnection.getUsername();
+            reactivateSubscriptions(oldSession, username);
+
+            // mark as connected
+            final boolean connecting = oldSession.assignState(Session.SessionStatus.DISCONNECTED, Session.SessionStatus.CONNECTING);
+            if (!connecting) {
+                throw new SessionCorruptedException("old session moved in connected state by other thread");
+            }
+            oldSession.bind(mqttConnection);
+
+            final boolean connected = oldSession.assignState(Session.SessionStatus.CONNECTING, Session.SessionStatus.CONNECTED);
+            if (!connected) {
+                throw new SessionCorruptedException("old session moved in other state state by other thread");
+            }
+
+            // publish new session
+            final boolean published = pool.replace(clientId, oldSession, oldSession);
+            if (!published) {
+                throw new SessionCorruptedException("old session was already removed");
+            }
+            postConnectAction = PostConnectAction.SEND_STORED_MESSAGES;
+            LOG.trace("case 3, oldSession with same CId {} disconnected", clientId);
+        } else if (oldSession.connected()) {
+            // case 4
+            LOG.trace("case 4, oldSession with same CId {} still connected, force to close", clientId);
+            oldSession.closeImmediately();
+            //remove(clientId);
+            // publish new session
+            final boolean published = pool.replace(clientId, oldSession, newSession);
+            if (!published) {
+                throw new SessionCorruptedException("old session was already removed");
+            }
+        }
+        // case not covered new session is clean true/false and old session not in CONNECTED/DISCONNECTED
+        return postConnectAction;
+    }
+
+    private void reactivateSubscriptions(Session session, String username) {
+        //verify if subscription still satisfy read ACL permissions
+        for (Subscription existingSub : session.getSubscriptions()) {
+            final boolean topicReadable = authorizator.canRead(existingSub.getTopicFilter(), username,
+                                                               session.getClientID());
+            if (!topicReadable) {
+                subscriptionsDirectory.removeSubscription(existingSub.getTopicFilter(), session.getClientID());
+            }
+            // TODO
+//            subscriptionsDirectory.reactivate(existingSub.getTopicFilter(), session.getClientID());
+        }
+    }
+
+    private void unsubscribe(Session session) {
+        for (Subscription existingSub : session.getSubscriptions()) {
+            subscriptionsDirectory.removeSubscription(existingSub.getTopicFilter(), session.getClientID());
+        }
+    }
+
+    private Session createNewSession(MQTTConnection mqttConnection, MqttConnectMessage msg, String clientId) {
+        final boolean clean = msg.variableHeader().isCleanSession();
+        final Queue<SessionRegistry.EnqueuedMessage> sessionQueue =
+                    queues.computeIfAbsent(clientId, (String cli) -> queueRepository.createQueue(cli, clean));
+        final Session newSession;
+        if (msg.variableHeader().isWillFlag()) {
+            final Session.Will will = createWill(msg);
+            newSession = new Session(clientId, clean, will, sessionQueue);
+        } else {
+            newSession = new Session(clientId, clean, sessionQueue);
+        }
+
+        newSession.markConnected();
+        newSession.bind(mqttConnection);
+
+        return newSession;
+    }
+
+    private void copySessionConfig(MqttConnectMessage msg, Session session) {
+        final boolean clean = msg.variableHeader().isCleanSession();
+        final Session.Will will;
+        if (msg.variableHeader().isWillFlag()) {
+            will = createWill(msg);
+        } else {
+            will = null;
+        }
+        session.update(clean, will);
+    }
+
+    private Session.Will createWill(MqttConnectMessage msg) {
+        final ByteBuf willPayload = Unpooled.copiedBuffer(msg.payload().willMessageInBytes());
+        final String willTopic = msg.payload().willTopic();
+        final boolean retained = msg.variableHeader().isWillRetain();
+        final MqttQoS qos = MqttQoS.valueOf(msg.variableHeader().willQos());
+        return new Session.Will(willTopic, willPayload, qos, retained);
+    }
+
+    Session retrieve(String clientID) {
+        return pool.get(clientID);
+    }
+
+    public void remove(String clientID) {
+        pool.remove(clientID);
+    }
+
+    public void disconnect(String clientID) {
+        final Session session = retrieve(clientID);
+        if (session == null) {
+            LOG.debug("Some other thread already removed the session CId={}", clientID);
+            return;
+        }
+        session.disconnect();
+    }
+
+    private void dropQueuesForClient(String clientId) {
+        queues.remove(clientId);
+    }
+
+    Collection<ClientDescriptor> listConnectedClients() {
+        return pool.values().stream()
+            .filter(Session::connected)
+            .map(this::createClientDescriptor)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toList());
+    }
+
+    private Optional<ClientDescriptor> createClientDescriptor(Session s) {
+        final String clientID = s.getClientID();
+        final Optional<InetSocketAddress> remoteAddressOpt = s.remoteAddress();
+        return remoteAddressOpt.map(r -> new ClientDescriptor(clientID, r.getHostString(), r.getPort()));
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/Utils.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/Utils.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader;
+import java.util.Map;
+
+/**
+ * Utility static methods, like Map get with default value, or elvis operator.
+ */
+public final class Utils {
+
+    public static <T, K> T defaultGet(Map<K, T> map, K key, T defaultValue) {
+        T value = map.get(key);
+        if (value != null) {
+            return value;
+        }
+        return defaultValue;
+    }
+
+    public static int messageId(MqttMessage msg) {
+        return ((MqttMessageIdVariableHeader) msg.variableHeader()).messageId();
+    }
+
+    public static byte[] readBytesAndRewind(ByteBuf payload) {
+        byte[] payloadContent = new byte[payload.readableBytes()];
+        int mark = payload.readerIndex();
+        payload.readBytes(payloadContent);
+        payload.readerIndex(mark);
+        return payloadContent;
+    }
+
+    private Utils() {
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/config/ClasspathResourceLoader.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/config/ClasspathResourceLoader.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.config;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClasspathResourceLoader implements IResourceLoader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClasspathResourceLoader.class);
+
+    private final String defaultResource;
+    private final ClassLoader classLoader;
+
+    public ClasspathResourceLoader() {
+        this(IConfig.DEFAULT_CONFIG);
+    }
+
+    public ClasspathResourceLoader(String defaultResource) {
+        this(defaultResource, Thread.currentThread().getContextClassLoader());
+    }
+
+    public ClasspathResourceLoader(String defaultResource, ClassLoader classLoader) {
+        this.defaultResource = defaultResource;
+        this.classLoader = classLoader;
+    }
+
+    @Override
+    public Reader loadDefaultResource() {
+        return loadResource(defaultResource);
+    }
+
+    @Override
+    public Reader loadResource(String relativePath) {
+        LOG.info("Loading resource. RelativePath = {}.", relativePath);
+        InputStream is = this.classLoader.getResourceAsStream(relativePath);
+        return is != null ? new InputStreamReader(is, StandardCharsets.UTF_8) : null;
+    }
+
+    @Override
+    public String getName() {
+        return "classpath resource";
+    }
+
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/config/ConfigurationParser.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/config/ConfigurationParser.java
@@ -18,6 +18,7 @@ package com.echostreams.pulsar.mqtt.broker.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -29,7 +30,7 @@ import java.util.Properties;
 
 /**
  * Mosquitto configuration parser.
- *
+ * <p>
  * A line that at the very first has # is a comment Each line has key value format, where the
  * separator used it the space.
  */
@@ -65,8 +66,7 @@ class ConfigurationParser {
     /**
      * Parse the configuration
      *
-     * @throws ParseException
-     *             if the format is not compliant.
+     * @throws ParseException if the format is not compliant.
      */
     void parse(Reader reader) throws ParseException {
         if (reader == null) {

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/config/ConfigurationParser.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/config/ConfigurationParser.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.text.ParseException;
+import java.util.Properties;
+
+/**
+ * Mosquitto configuration parser.
+ *
+ * A line that at the very first has # is a comment Each line has key value format, where the
+ * separator used it the space.
+ */
+class ConfigurationParser {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigurationParser.class);
+
+    private Properties m_properties = new Properties();
+
+    /**
+     * Parse the configuration from file.
+     */
+    void parse(File file) throws ParseException {
+        if (file == null) {
+            LOG.warn("parsing NULL file, so fallback on default configuration!");
+            return;
+        }
+        if (!file.exists()) {
+            LOG.warn(
+                    String.format(
+                            "parsing not existing file %s, so fallback on default configuration!",
+                            file.getAbsolutePath()));
+            return;
+        }
+        try {
+            Reader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8);
+            parse(reader);
+        } catch (IOException fex) {
+            LOG.warn("parsing not existing file {}, fallback on default configuration!", file.getAbsolutePath(), fex);
+        }
+    }
+
+    /**
+     * Parse the configuration
+     *
+     * @throws ParseException
+     *             if the format is not compliant.
+     */
+    void parse(Reader reader) throws ParseException {
+        if (reader == null) {
+            // just log and return default properties
+            LOG.warn("parsing NULL reader, so fallback on default configuration!");
+            return;
+        }
+
+        BufferedReader br = new BufferedReader(reader);
+        String line;
+        try {
+            while ((line = br.readLine()) != null) {
+                int commentMarker = line.indexOf('#');
+                if (commentMarker != -1) {
+                    if (commentMarker == 0) {
+                        // skip its a comment
+                        continue;
+                    } else {
+                        // it's a malformed comment
+                        throw new ParseException(line, commentMarker);
+                    }
+                } else {
+                    if (line.isEmpty() || line.matches("^\\s*$")) {
+                        // skip it's a black line
+                        continue;
+                    }
+
+                    // split till the first space
+                    int delimiterIdx = line.indexOf(' ');
+                    String key = line.substring(0, delimiterIdx).trim();
+                    String value = line.substring(delimiterIdx).trim();
+
+                    m_properties.put(key, value);
+                }
+            }
+        } catch (IOException ex) {
+            throw new ParseException("Failed to read", 1);
+        } finally {
+            try {
+                reader.close();
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+    }
+
+    Properties getProperties() {
+        return m_properties;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/config/ConfigurationParser.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/config/ConfigurationParser.java
@@ -16,6 +16,9 @@
 
 package com.echostreams.pulsar.mqtt.broker.config;
 
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.utils.TopicUtils;
+import org.h2.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,6 +101,13 @@ class ConfigurationParser {
                     int delimiterIdx = line.indexOf(' ');
                     String key = line.substring(0, delimiterIdx).trim();
                     String value = line.substring(delimiterIdx).trim();
+
+                    // validate for message storage type value persistent or non-persistent only
+                    if (!StringUtils.isNullOrEmpty(key) && BrokerConstants.MESSAGE_STORAGE_TYPE_PROPERTY_NAME.equals(key)) {
+                        if (!TopicUtils.isValidMessageStorageTypeName(value)) {
+                            throw new ParseException(BrokerConstants.MESSAGE_STORAGE_TYPE_PROPERTY_NAME + " must be persistent or non-persistent only", 1);
+                        }
+                    }
 
                     m_properties.put(key, value);
                 }

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/config/FileResourceLoader.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/config/FileResourceLoader.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.config;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class FileResourceLoader implements IResourceLoader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileResourceLoader.class);
+
+    private final File defaultFile;
+    private final String parentPath;
+
+    public FileResourceLoader() {
+        this((File) null);
+    }
+
+    public FileResourceLoader(File defaultFile) {
+        this(defaultFile, System.getProperty("moquette.path", null));
+    }
+
+    public FileResourceLoader(String parentPath) {
+        this(null, parentPath);
+    }
+
+    public FileResourceLoader(File defaultFile, String parentPath) {
+        this.defaultFile = defaultFile;
+        this.parentPath = parentPath;
+    }
+
+    @Override
+    public Reader loadDefaultResource() {
+        if (defaultFile != null) {
+            return loadResource(defaultFile);
+        } else {
+            throw new IllegalArgumentException("Default file not set!");
+        }
+    }
+
+    @Override
+    public Reader loadResource(String relativePath) {
+        return loadResource(new File(parentPath, relativePath));
+    }
+
+    public Reader loadResource(File f) {
+        LOG.info("Loading file. Path = {}.", f.getAbsolutePath());
+        if (f.isDirectory()) {
+            LOG.error("The given file is a directory. Path = {}.", f.getAbsolutePath());
+            throw new ResourceIsDirectoryException("File \"" + f + "\" is a directory!");
+        }
+        try {
+            return Files.newBufferedReader(f.toPath(), UTF_8);
+        } catch (IOException e) {
+            LOG.error("The file does not exist. Path = {}.", f.getAbsolutePath());
+            return null;
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "file";
+    }
+
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/config/IConfig.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/config/IConfig.java
@@ -17,13 +17,14 @@
 package com.echostreams.pulsar.mqtt.broker.config;
 
 import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.utils.CommonUtils;
 
 /**
  * Base interface for all configuration implementations (filesystem, memory or classpath)
  */
 public abstract class IConfig {
 
-    public static final String DEFAULT_CONFIG = "config/moquette.conf";
+    public static final String DEFAULT_CONFIG = "application.properties";
 
     public abstract void setProperty(String name, String value);
 
@@ -32,16 +33,16 @@ public abstract class IConfig {
      *
      * @param name property name.
      * @return property value.
-     * */
+     */
     public abstract String getProperty(String name);
 
     /**
      * Same semantic of Properties
      *
-     * @param name property name.
+     * @param name         property name.
      * @param defaultValue default value to return in case the property doesn't exists.
      * @return property value.
-     * */
+     */
     public abstract String getProperty(String name, String defaultValue);
 
     void assignDefaults() {
@@ -56,7 +57,19 @@ public abstract class IConfig {
         setProperty(BrokerConstants.AUTHENTICATOR_CLASS_NAME, "");
         setProperty(BrokerConstants.AUTHORIZATOR_CLASS_NAME, "");
         setProperty(BrokerConstants.NETTY_MAX_BYTES_PROPERTY_NAME,
-            String.valueOf(BrokerConstants.DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE));
+                String.valueOf(BrokerConstants.DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE));
+
+        setProperty(BrokerConstants.PERSISTENT_PROPERTY_NAME, BrokerConstants.PERSISTENT_NAME);
+        setProperty(BrokerConstants.TENANT_PROPERTY_NAME, BrokerConstants.TENANT_NAME);
+        setProperty(BrokerConstants.NAMESPACE_PROPERTY_NAME, BrokerConstants.NAMESPACE_NAME);
+
+        // create topic prefix like this persistent://my-tenant/my-namespace
+        String pulsarDefaultTopicNamePrefix = CommonUtils.createTopicNameWithPrefix(
+                getProperty(BrokerConstants.PERSISTENT_PROPERTY_NAME),
+                getProperty(BrokerConstants.TENANT_PROPERTY_NAME),
+                getProperty(BrokerConstants.NAMESPACE_PROPERTY_NAME), null);
+        setProperty(BrokerConstants.PULSAR_TOPIC_NAME_PREFIX, pulsarDefaultTopicNamePrefix);
+
     }
 
     public abstract IResourceLoader getResourceLoader();

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/config/IConfig.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/config/IConfig.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.config;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+
+/**
+ * Base interface for all configuration implementations (filesystem, memory or classpath)
+ */
+public abstract class IConfig {
+
+    public static final String DEFAULT_CONFIG = "config/moquette.conf";
+
+    public abstract void setProperty(String name, String value);
+
+    /**
+     * Same semantic of Properties
+     *
+     * @param name property name.
+     * @return property value.
+     * */
+    public abstract String getProperty(String name);
+
+    /**
+     * Same semantic of Properties
+     *
+     * @param name property name.
+     * @param defaultValue default value to return in case the property doesn't exists.
+     * @return property value.
+     * */
+    public abstract String getProperty(String name, String defaultValue);
+
+    void assignDefaults() {
+        setProperty(BrokerConstants.PORT_PROPERTY_NAME, Integer.toString(BrokerConstants.PORT));
+        setProperty(BrokerConstants.HOST_PROPERTY_NAME, BrokerConstants.HOST);
+        // setProperty(BrokerConstants.WEB_SOCKET_PORT_PROPERTY_NAME,
+        // Integer.toString(BrokerConstants.WEBSOCKET_PORT));
+        setProperty(BrokerConstants.PASSWORD_FILE_PROPERTY_NAME, "");
+        // setProperty(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME,
+        // BrokerConstants.DEFAULT_PERSISTENT_PATH);
+        setProperty(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, Boolean.TRUE.toString());
+        setProperty(BrokerConstants.AUTHENTICATOR_CLASS_NAME, "");
+        setProperty(BrokerConstants.AUTHORIZATOR_CLASS_NAME, "");
+        setProperty(BrokerConstants.NETTY_MAX_BYTES_PROPERTY_NAME,
+            String.valueOf(BrokerConstants.DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE));
+    }
+
+    public abstract IResourceLoader getResourceLoader();
+
+    public int intProp(String propertyName, int defaultValue) {
+        String propertyValue = getProperty(propertyName);
+        if (propertyValue == null) {
+            return defaultValue;
+        }
+        return Integer.parseInt(propertyValue);
+    }
+
+    public boolean boolProp(String propertyName, boolean defaultValue) {
+        String propertyValue = getProperty(propertyName);
+        if (propertyValue == null) {
+            return defaultValue;
+        }
+        return Boolean.parseBoolean(propertyValue);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/config/IConfig.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/config/IConfig.java
@@ -17,7 +17,6 @@
 package com.echostreams.pulsar.mqtt.broker.config;
 
 import com.echostreams.pulsar.mqtt.BrokerConstants;
-import com.echostreams.pulsar.mqtt.broker.utils.CommonUtils;
 
 /**
  * Base interface for all configuration implementations (filesystem, memory or classpath)
@@ -58,17 +57,6 @@ public abstract class IConfig {
         setProperty(BrokerConstants.AUTHORIZATOR_CLASS_NAME, "");
         setProperty(BrokerConstants.NETTY_MAX_BYTES_PROPERTY_NAME,
                 String.valueOf(BrokerConstants.DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE));
-
-        setProperty(BrokerConstants.PERSISTENT_PROPERTY_NAME, BrokerConstants.PERSISTENT_NAME);
-        setProperty(BrokerConstants.TENANT_PROPERTY_NAME, BrokerConstants.TENANT_NAME);
-        setProperty(BrokerConstants.NAMESPACE_PROPERTY_NAME, BrokerConstants.NAMESPACE_NAME);
-
-        // create topic prefix like this persistent://my-tenant/my-namespace
-        String pulsarDefaultTopicNamePrefix = CommonUtils.createTopicNameWithPrefix(
-                getProperty(BrokerConstants.PERSISTENT_PROPERTY_NAME),
-                getProperty(BrokerConstants.TENANT_PROPERTY_NAME),
-                getProperty(BrokerConstants.NAMESPACE_PROPERTY_NAME), null);
-        setProperty(BrokerConstants.PULSAR_TOPIC_NAME_PREFIX, pulsarDefaultTopicNamePrefix);
 
     }
 

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/config/IResourceLoader.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/config/IResourceLoader.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.config;
+
+import java.io.Reader;
+
+public interface IResourceLoader {
+
+    Reader loadDefaultResource();
+
+    Reader loadResource(String relativePath);
+
+    String getName();
+
+    class ResourceIsDirectoryException extends RuntimeException {
+
+        private static final long serialVersionUID = -6969292229582764176L;
+
+        public ResourceIsDirectoryException(String message) {
+            super(message);
+        }
+    }
+
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/config/MemoryConfig.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/config/MemoryConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.config;
+
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Configuration backed by memory.
+ */
+public class MemoryConfig extends IConfig {
+
+    private final Properties m_properties = new Properties();
+
+    public MemoryConfig(Properties properties) {
+        assignDefaults();
+        for (Map.Entry<Object, Object> entrySet : properties.entrySet()) {
+            m_properties.put(entrySet.getKey(), entrySet.getValue());
+        }
+    }
+
+    // private void createDefaults() {
+    // m_properties.put(BrokerConstants.PORT_PROPERTY_NAME, Integer.toString(BrokerConstants.PORT));
+    // m_properties.put(BrokerConstants.HOST_PROPERTY_NAME, BrokerConstants.HOST);
+    // m_properties.put(BrokerConstants.WEB_SOCKET_PORT_PROPERTY_NAME,
+    // Integer.toString(BrokerConstants.WEBSOCKET_PORT));
+    // m_properties.put(BrokerConstants.PASSWORD_FILE_PROPERTY_NAME, "");
+    // m_properties.put(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME,
+    // BrokerConstants.DEFAULT_PERSISTENT_PATH);
+    // m_properties.put(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, true);
+    // m_properties.put(BrokerConstants.AUTHENTICATOR_CLASS_NAME, "");
+    // m_properties.put(BrokerConstants.AUTHORIZATOR_CLASS_NAME, "");
+    // }
+
+    @Override
+    public void setProperty(String name, String value) {
+        m_properties.setProperty(name, value);
+    }
+
+    @Override
+    public String getProperty(String name) {
+        return m_properties.getProperty(name);
+    }
+
+    @Override
+    public String getProperty(String name, String defaultValue) {
+        return m_properties.getProperty(name, defaultValue);
+    }
+
+    @Override
+    public IResourceLoader getResourceLoader() {
+        return new FileResourceLoader();
+    }
+
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/config/ResourceLoaderConfig.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/config/ResourceLoaderConfig.java
@@ -18,6 +18,7 @@ package com.echostreams.pulsar.mqtt.broker.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import java.io.Reader;
 import java.text.ParseException;
 import java.util.Properties;
@@ -72,7 +73,7 @@ public class ResourceLoaderConfig extends IConfig {
         } catch (ParseException pex) {
             LOG.warn(
                     "Unable to parse configuration properties. Using default configuration. "
-                    + "ResourceLoader = {}, configName = {}, cause = {}, errorMessage = {}.",
+                            + "ResourceLoader = {}, configName = {}, cause = {}, errorMessage = {}.",
                     resourceLoader.getName(),
                     configName,
                     pex.getCause(),

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/config/ResourceLoaderConfig.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/config/ResourceLoaderConfig.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.Reader;
+import java.text.ParseException;
+import java.util.Properties;
+
+/**
+ * Configuration that loads config stream from a {@link IResourceLoader} instance.
+ */
+public class ResourceLoaderConfig extends IConfig {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ResourceLoaderConfig.class);
+
+    private final Properties m_properties;
+    private final IResourceLoader resourceLoader;
+
+    public ResourceLoaderConfig(IResourceLoader resourceLoader) {
+        this(resourceLoader, null);
+    }
+
+    public ResourceLoaderConfig(IResourceLoader resourceLoader, String configName) {
+        LOG.info("Loading configuration. ResourceLoader = {}, configName = {}.", resourceLoader.getName(), configName);
+        this.resourceLoader = resourceLoader;
+
+        /*
+         * If we use a conditional operator, the loadResource() and the loadDefaultResource()
+         * methods will be always called. This makes the log traces confusing.
+         */
+
+        Reader configReader;
+        if (configName != null) {
+            configReader = resourceLoader.loadResource(configName);
+        } else {
+            configReader = resourceLoader.loadDefaultResource();
+        }
+
+        if (configReader == null) {
+            LOG.error(
+                    "The resource loader returned no configuration reader. ResourceLoader = {}, configName = {}.",
+                    resourceLoader.getName(),
+                    configName);
+            throw new IllegalArgumentException("Can't locate " + resourceLoader.getName() + " \"" + configName + "\"");
+        }
+
+        LOG.info(
+                "Parsing configuration properties. ResourceLoader = {}, configName = {}.",
+                resourceLoader.getName(),
+                configName);
+        ConfigurationParser confParser = new ConfigurationParser();
+        m_properties = confParser.getProperties();
+        assignDefaults();
+        try {
+            confParser.parse(configReader);
+        } catch (ParseException pex) {
+            LOG.warn(
+                    "Unable to parse configuration properties. Using default configuration. "
+                    + "ResourceLoader = {}, configName = {}, cause = {}, errorMessage = {}.",
+                    resourceLoader.getName(),
+                    configName,
+                    pex.getCause(),
+                    pex.getMessage());
+        }
+    }
+
+    @Override
+    public void setProperty(String name, String value) {
+        m_properties.setProperty(name, value);
+    }
+
+    @Override
+    public String getProperty(String name) {
+        return m_properties.getProperty(name);
+    }
+
+    @Override
+    public String getProperty(String name, String defaultValue) {
+        return m_properties.getProperty(name, defaultValue);
+    }
+
+    @Override
+    public IResourceLoader getResourceLoader() {
+        return resourceLoader;
+    }
+
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/BytesMetrics.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/BytesMetrics.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.metrics;
+
+public class BytesMetrics {
+
+    private long m_readBytes;
+    private long m_wroteBytes;
+
+    void incrementRead(long numBytes) {
+        m_readBytes += numBytes;
+    }
+
+    void incrementWrote(long numBytes) {
+        m_wroteBytes += numBytes;
+    }
+
+    public long readBytes() {
+        return m_readBytes;
+    }
+
+    public long wroteBytes() {
+        return m_wroteBytes;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/BytesMetricsCollector.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/BytesMetricsCollector.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.metrics;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Collects all the metrics from the various pipeline.
+ */
+public class BytesMetricsCollector {
+
+    private AtomicLong readBytes = new AtomicLong();
+    private AtomicLong wroteBytes = new AtomicLong();
+
+    public BytesMetrics computeMetrics() {
+        BytesMetrics allMetrics = new BytesMetrics();
+        allMetrics.incrementRead(readBytes.get());
+        allMetrics.incrementWrote(wroteBytes.get());
+        return allMetrics;
+    }
+
+    public void sumReadBytes(long count) {
+        readBytes.getAndAdd(count);
+    }
+
+    public void sumWroteBytes(long count) {
+        wroteBytes.getAndAdd(count);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/BytesMetricsHandler.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/BytesMetricsHandler.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.metrics;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+
+import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
+
+public class BytesMetricsHandler extends ChannelDuplexHandler {
+
+    private static final AttributeKey<BytesMetrics> ATTR_KEY_METRICS = AttributeKey.valueOf("BytesMetrics");
+
+    private BytesMetricsCollector m_collector;
+
+    public BytesMetricsHandler(BytesMetricsCollector collector) {
+        m_collector = collector;
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        Attribute<BytesMetrics> attr = ctx.channel().attr(ATTR_KEY_METRICS);
+        attr.set(new BytesMetrics());
+
+        super.channelActive(ctx);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        BytesMetrics metrics = ctx.channel().attr(ATTR_KEY_METRICS).get();
+        metrics.incrementRead(((ByteBuf) msg).readableBytes());
+        ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        BytesMetrics metrics = ctx.channel().attr(ATTR_KEY_METRICS).get();
+        metrics.incrementWrote(((ByteBuf) msg).writableBytes());
+        ctx.write(msg, promise).addListener(CLOSE_ON_FAILURE);
+    }
+
+    @Override
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        BytesMetrics metrics = ctx.channel().attr(ATTR_KEY_METRICS).get();
+        m_collector.sumReadBytes(metrics.readBytes());
+        m_collector.sumWroteBytes(metrics.wroteBytes());
+        super.close(ctx, promise);
+    }
+
+    public static BytesMetrics getBytesMetrics(Channel channel) {
+        return channel.attr(ATTR_KEY_METRICS).get();
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/DropWizardMetricsHandler.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/DropWizardMetricsHandler.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker.metrics;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.librato.metrics.reporter.Librato;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import com.echostreams.pulsar.mqtt.broker.NettyUtils;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.echostreams.pulsar.mqtt.BrokerConstants.*;
+import static io.netty.channel.ChannelHandler.Sharable;
+
+/**
+ * Pipeline handler use to track some MQTT metrics.
+ */
+@Sharable
+public final class DropWizardMetricsHandler extends ChannelInboundHandlerAdapter {
+    private MetricRegistry metrics;
+    private Meter publishesMetrics;
+    private Meter subscribeMetrics;
+    private Counter connectedClientsMetrics;
+
+    public void init(IConfig props) {
+        this.metrics = new MetricRegistry();
+        this.publishesMetrics = metrics.meter("publish.requests");
+        this.subscribeMetrics = metrics.meter("subscribe.requests");
+        this.connectedClientsMetrics = metrics.counter("connect.num_clients");
+//        ConsoleReporter reporter = ConsoleReporter.forRegistry(metrics)
+//            .convertRatesTo(TimeUnit.SECONDS)
+//            .convertDurationsTo(TimeUnit.MILLISECONDS)
+//            .build();
+//        reporter.start(1, TimeUnit.MINUTES);
+        final String email = props.getProperty(METRICS_LIBRATO_EMAIL_PROPERTY_NAME);
+        final String token = props.getProperty(METRICS_LIBRATO_TOKEN_PROPERTY_NAME);
+        final String source = props.getProperty(METRICS_LIBRATO_SOURCE_PROPERTY_NAME);
+
+        Librato.reporter(this.metrics, email, token)
+            .setSource(source)
+            .start(10, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object message) {
+        MqttMessage msg = (MqttMessage) message;
+        MqttMessageType messageType = msg.fixedHeader().messageType();
+        switch (messageType) {
+            case PUBLISH:
+                this.publishesMetrics.mark();
+                break;
+            case SUBSCRIBE:
+                this.subscribeMetrics.mark();
+                break;
+            case CONNECT:
+                this.connectedClientsMetrics.inc();
+                break;
+            case DISCONNECT:
+                this.connectedClientsMetrics.dec();
+                break;
+            default:
+                break;
+        }
+        ctx.fireChannelRead(message);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        String clientID = NettyUtils.clientID(ctx.channel());
+        if (clientID != null && !clientID.isEmpty()) {
+            this.connectedClientsMetrics.dec();
+        }
+        ctx.fireChannelInactive();
+    }
+
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/DropWizardMetricsHandler.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/DropWizardMetricsHandler.java
@@ -20,7 +20,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.librato.metrics.reporter.Librato;
 import com.echostreams.pulsar.mqtt.broker.config.IConfig;
-import com.echostreams.pulsar.mqtt.broker.NettyUtils;
+import com.echostreams.pulsar.mqtt.broker.utils.NettyUtils;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.mqtt.MqttMessage;

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/MQTTMessageLogger.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/MQTTMessageLogger.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.metrics;
+
+import com.echostreams.pulsar.mqtt.broker.NettyUtils;
+import com.echostreams.pulsar.mqtt.broker.Utils;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.mqtt.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
+
+/**
+ *
+ * @author andrea
+ */
+@Sharable
+public class MQTTMessageLogger extends ChannelDuplexHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MQTTMessageLogger.class);
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object message) throws Exception {
+        logMQTTMessageRead(ctx, message);
+        ctx.fireChannelRead(message);
+    }
+
+    private void logMQTTMessageRead(ChannelHandlerContext ctx, Object message) throws Exception {
+        logMQTTMessage(ctx, message, "C->B");
+    }
+
+    private void logMQTTMessageWrite(ChannelHandlerContext ctx, Object message) throws Exception {
+        logMQTTMessage(ctx, message, "C<-B");
+    }
+
+    private void logMQTTMessage(ChannelHandlerContext ctx, Object message, String direction) throws Exception {
+        if (!(message instanceof MqttMessage)) {
+            return;
+        }
+        MqttMessage msg = NettyUtils.validateMessage(message);
+        String clientID = NettyUtils.clientID(ctx.channel());
+        MqttMessageType messageType = msg.fixedHeader().messageType();
+        switch (messageType) {
+            case CONNACK:
+            case PINGREQ:
+            case PINGRESP:
+                LOG.debug("{} {} <{}>", direction, messageType, clientID);
+                break;
+            case CONNECT:
+            case DISCONNECT:
+                LOG.info("{} {} <{}>", direction, messageType, clientID);
+                break;
+            case SUBSCRIBE:
+                MqttSubscribeMessage subscribe = (MqttSubscribeMessage) msg;
+                LOG.info("{} SUBSCRIBE <{}> to topics {}", direction, clientID,
+                    subscribe.payload().topicSubscriptions());
+                break;
+            case UNSUBSCRIBE:
+                MqttUnsubscribeMessage unsubscribe = (MqttUnsubscribeMessage) msg;
+                LOG.info("{} UNSUBSCRIBE <{}> to topics <{}>", direction, clientID, unsubscribe.payload().topics());
+                break;
+            case PUBLISH:
+                MqttPublishMessage publish = (MqttPublishMessage) msg;
+                LOG.debug("{} PUBLISH <{}> to topics <{}>", direction, clientID, publish.variableHeader().topicName());
+                break;
+            case PUBREC:
+            case PUBCOMP:
+            case PUBREL:
+            case PUBACK:
+            case UNSUBACK:
+                LOG.info("{} {} <{}> packetID <{}>", direction, messageType, clientID, Utils.messageId(msg));
+                break;
+            case SUBACK:
+                MqttSubAckMessage suback = (MqttSubAckMessage) msg;
+                final List<Integer> grantedQoSLevels = suback.payload().grantedQoSLevels();
+                LOG.info("{} SUBACK <{}> packetID <{}>, grantedQoses {}", direction, clientID, Utils.messageId(msg),
+                    grantedQoSLevels);
+                break;
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        String clientID = NettyUtils.clientID(ctx.channel());
+        if (clientID != null && !clientID.isEmpty()) {
+            LOG.info("Channel closed <{}>", clientID);
+        }
+        ctx.fireChannelInactive();
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        logMQTTMessageWrite(ctx, msg);
+        ctx.write(msg, promise).addListener(CLOSE_ON_FAILURE);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/MQTTMessageLogger.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/MQTTMessageLogger.java
@@ -16,8 +16,8 @@
 
 package com.echostreams.pulsar.mqtt.broker.metrics;
 
-import com.echostreams.pulsar.mqtt.broker.NettyUtils;
-import com.echostreams.pulsar.mqtt.broker.Utils;
+import com.echostreams.pulsar.mqtt.broker.utils.NettyUtils;
+import com.echostreams.pulsar.mqtt.broker.utils.Utils;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/MessageMetrics.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/MessageMetrics.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.metrics;
+
+public class MessageMetrics {
+
+    private long m_messagesRead;
+    private long m_messageWrote;
+
+    void incrementRead(long numMessages) {
+        m_messagesRead += numMessages;
+    }
+
+    void incrementWrote(long numMessages) {
+        m_messageWrote += numMessages;
+    }
+
+    public long messagesRead() {
+        return m_messagesRead;
+    }
+
+    public long messagesWrote() {
+        return m_messageWrote;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/MessageMetricsCollector.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/MessageMetricsCollector.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.metrics;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Collects all the metrics from the various pipeline.
+ */
+public class MessageMetricsCollector {
+
+    private AtomicLong readMsgs = new AtomicLong();
+    private AtomicLong wroteMsgs = new AtomicLong();
+
+    public MessageMetrics computeMetrics() {
+        MessageMetrics allMetrics = new MessageMetrics();
+        allMetrics.incrementRead(readMsgs.get());
+        allMetrics.incrementWrote(wroteMsgs.get());
+        return allMetrics;
+    }
+
+    public void sumReadMessages(long count) {
+        readMsgs.getAndAdd(count);
+    }
+
+    public void sumWroteMessages(long count) {
+        wroteMsgs.getAndAdd(count);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/MessageMetricsHandler.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/metrics/MessageMetricsHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.metrics;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+
+import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
+
+public class MessageMetricsHandler extends ChannelDuplexHandler {
+
+    private static final AttributeKey<MessageMetrics> ATTR_KEY_METRICS = AttributeKey.valueOf("MessageMetrics");
+
+    private MessageMetricsCollector m_collector;
+
+    public MessageMetricsHandler(MessageMetricsCollector collector) {
+        m_collector = collector;
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        Attribute<MessageMetrics> attr = ctx.channel().attr(ATTR_KEY_METRICS);
+        attr.set(new MessageMetrics());
+
+        super.channelActive(ctx);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        MessageMetrics metrics = ctx.channel().attr(ATTR_KEY_METRICS).get();
+        metrics.incrementRead(1);
+        ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        MessageMetrics metrics = ctx.channel().attr(ATTR_KEY_METRICS).get();
+        metrics.incrementWrote(1);
+        ctx.write(msg, promise).addListener(CLOSE_ON_FAILURE);
+    }
+
+    @Override
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        MessageMetrics metrics = ctx.channel().attr(ATTR_KEY_METRICS).get();
+        m_collector.sumReadMessages(metrics.messagesRead());
+        m_collector.sumWroteMessages(metrics.messagesWrote());
+        super.close(ctx, promise);
+    }
+
+    public static MessageMetrics getMessageMetrics(Channel channel) {
+        return channel.attr(ATTR_KEY_METRICS).get();
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/security/ACLFileParser.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/security/ACLFileParser.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.text.ParseException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Parses the acl configuration file. If a line starts with # it's comment. Blank lines are skipped.
+ * The format is "topic [read|write|readwrite] {topic name}"
+ */
+public final class ACLFileParser {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ACLFileParser.class);
+
+    /**
+     * Parse the configuration from file.
+     *
+     * @param file
+     *            to parse
+     * @return the collector of authorizations form reader passed into.
+     * @throws ParseException
+     *             if the format is not compliant.
+     */
+    public static AuthorizationsCollector parse(File file) throws ParseException {
+        if (file == null) {
+            LOG.warn("parsing NULL file, so fallback on default configuration!");
+            return AuthorizationsCollector.emptyImmutableCollector();
+        }
+        if (!file.exists()) {
+            LOG.warn(
+                    String.format(
+                            "parsing not existing file %s, so fallback on default configuration!",
+                            file.getAbsolutePath()));
+            return AuthorizationsCollector.emptyImmutableCollector();
+        }
+        try {
+            Reader reader = Files.newBufferedReader(file.toPath(), UTF_8);
+            return parse(reader);
+        } catch (IOException fex) {
+            LOG.warn(
+                    String.format(
+                            "parsing not existing file %s, so fallback on default configuration!",
+                            file.getAbsolutePath()),
+                    fex);
+            return AuthorizationsCollector.emptyImmutableCollector();
+        }
+    }
+
+    /**
+     * Parse the ACL configuration file
+     *
+     * @param reader
+     *            to parse
+     * @return the collector of authorizations form reader passed into.
+     * @throws ParseException
+     *             if the format is not compliant.
+     */
+    public static AuthorizationsCollector parse(Reader reader) throws ParseException {
+        if (reader == null) {
+            // just log and return default properties
+            LOG.warn("parsing NULL reader, so fallback on default configuration!");
+            return AuthorizationsCollector.emptyImmutableCollector();
+        }
+
+        BufferedReader br = new BufferedReader(reader);
+        String line;
+        AuthorizationsCollector collector = new AuthorizationsCollector();
+
+        Pattern emptyLine = Pattern.compile("^\\s*$");
+        Pattern commentLine = Pattern.compile("^#.*"); // As spec, comment lines should start with '#'
+        Pattern invalidCommentLine = Pattern.compile("^\\s*#.*");
+        // This pattern has a dependency on filtering `commentLine`.
+        Pattern endLineComment = Pattern.compile("^([\\w\\s\\/\\+]+#?)(\\s*#.*)$");
+        Matcher endLineCommentMatcher;
+
+        try {
+            while ((line = br.readLine()) != null) {
+                if (line.isEmpty() || emptyLine.matcher(line).matches() || commentLine.matcher(line).matches()) {
+                    // skip it's a black line or comment
+                    continue;
+                } else if (invalidCommentLine.matcher(line).matches()) {
+                    // it's a malformed comment
+                    int commentMarker = line.indexOf('#');
+                    throw new ParseException(line, commentMarker);
+                }
+
+                endLineCommentMatcher = endLineComment.matcher(line);
+                if (endLineCommentMatcher.matches()) {
+                    line = endLineCommentMatcher.group(1);
+                }
+
+                collector.parse(line);
+            }
+        } catch (IOException ex) {
+            throw new ParseException("Failed to read", 1);
+        }
+        return collector;
+    }
+
+    private ACLFileParser() {
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/security/AcceptAllAuthenticator.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/security/AcceptAllAuthenticator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+public class AcceptAllAuthenticator implements IAuthenticator {
+
+    @Override
+    public boolean checkValid(String clientId, String username, byte[] password) {
+        return true;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/security/Authorization.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/security/Authorization.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+import static com.echostreams.pulsar.mqtt.broker.security.Authorization.Permission.READWRITE;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+
+/**
+ * Carries the read/write authorization to topics for the users.
+ */
+public class Authorization {
+
+    protected final Topic topic;
+    protected final Permission permission;
+
+    /**
+     * Access rights
+     */
+    enum Permission {
+        READ, WRITE, READWRITE
+    }
+
+    Authorization(Topic topic) {
+        this(topic, Permission.READWRITE);
+    }
+
+    Authorization(Topic topic, Permission permission) {
+        this.topic = topic;
+        this.permission = permission;
+    }
+
+    public boolean grant(Permission desiredPermission) {
+        return permission == desiredPermission || permission == READWRITE;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        Authorization that = (Authorization) o;
+
+        if (permission != that.permission)
+            return false;
+        if (!topic.equals(that.topic))
+            return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = topic.hashCode();
+        result = 31 * result + permission.hashCode();
+        return result;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/security/AuthorizationsCollector.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/security/AuthorizationsCollector.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+
+import java.text.ParseException;
+import java.util.*;
+
+/**
+ * Used by the ACLFileParser to push all authorizations it finds. ACLAuthorizator uses it in read
+ * mode to check it topics matches the ACLs.
+ *
+ * Not thread safe.
+ */
+class AuthorizationsCollector implements IAuthorizatorPolicy {
+
+    private List<Authorization> m_globalAuthorizations = new ArrayList<>();
+    private List<Authorization> m_patternAuthorizations = new ArrayList<>();
+    private Map<String, List<Authorization>> m_userAuthorizations = new HashMap<>();
+    private boolean m_parsingUsersSpecificSection;
+    private boolean m_parsingPatternSpecificSection;
+    private String m_currentUser = "";
+
+    static final AuthorizationsCollector emptyImmutableCollector() {
+        AuthorizationsCollector coll = new AuthorizationsCollector();
+        coll.m_globalAuthorizations = Collections.emptyList();
+        coll.m_patternAuthorizations = Collections.emptyList();
+        coll.m_userAuthorizations = Collections.emptyMap();
+        return coll;
+    }
+
+    void parse(String line) throws ParseException {
+        Authorization acl = parseAuthLine(line);
+        if (acl == null) {
+            // skip it's a user
+            return;
+        }
+        if (m_parsingUsersSpecificSection) {
+            // TODO in java 8 switch to m_userAuthorizations.putIfAbsent(m_currentUser, new
+            // ArrayList());
+            if (!m_userAuthorizations.containsKey(m_currentUser)) {
+                m_userAuthorizations.put(m_currentUser, new ArrayList<Authorization>());
+            }
+            List<Authorization> userAuths = m_userAuthorizations.get(m_currentUser);
+            userAuths.add(acl);
+        } else if (m_parsingPatternSpecificSection) {
+            m_patternAuthorizations.add(acl);
+        } else {
+            m_globalAuthorizations.add(acl);
+        }
+    }
+
+    protected Authorization parseAuthLine(String line) throws ParseException {
+        String[] tokens = line.split("\\s+");
+        String keyword = tokens[0].toLowerCase();
+        switch (keyword) {
+            case "topic":
+                return createAuthorization(line, tokens);
+            case "user":
+                m_parsingUsersSpecificSection = true;
+                m_currentUser = tokens[1];
+                m_parsingPatternSpecificSection = false;
+                return null;
+            case "pattern":
+                m_parsingUsersSpecificSection = false;
+                m_currentUser = "";
+                m_parsingPatternSpecificSection = true;
+                return createAuthorization(line, tokens);
+            default:
+                throw new ParseException(String.format("invalid line definition found %s", line), 1);
+        }
+    }
+
+    private Authorization createAuthorization(String line, String[] tokens) throws ParseException {
+        if (tokens.length > 2) {
+            // if the tokenized lines has 3 token the second must be the permission
+            try {
+                Authorization.Permission permission = Authorization.Permission.valueOf(tokens[1].toUpperCase());
+                // bring topic with all original spacing
+                Topic topic = new Topic(line.substring(line.indexOf(tokens[2])));
+
+                return new Authorization(topic, permission);
+            } catch (IllegalArgumentException iaex) {
+                throw new ParseException("invalid permission token", 1);
+            }
+        }
+        Topic topic = new Topic(tokens[1]);
+        return new Authorization(topic);
+    }
+
+    @Override
+    public boolean canWrite(Topic topic, String user, String client) {
+        return canDoOperation(topic, Authorization.Permission.WRITE, user, client);
+    }
+
+    @Override
+    public boolean canRead(Topic topic, String user, String client) {
+        return canDoOperation(topic, Authorization.Permission.READ, user, client);
+    }
+
+    private boolean canDoOperation(Topic topic, Authorization.Permission permission, String username, String client) {
+        if (matchACL(m_globalAuthorizations, topic, permission)) {
+            return true;
+        }
+
+        if (isNotEmpty(client) || isNotEmpty(username)) {
+            for (Authorization auth : m_patternAuthorizations) {
+                Topic substitutedTopic = new Topic(auth.topic.toString().replace("%c", client).replace("%u", username));
+                if (auth.grant(permission)) {
+                    if (topic.match(substitutedTopic)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        if (isNotEmpty(username)) {
+            if (m_userAuthorizations.containsKey(username)) {
+                List<Authorization> auths = m_userAuthorizations.get(username);
+                if (matchACL(auths, topic, permission)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean matchACL(List<Authorization> auths, Topic topic, Authorization.Permission permission) {
+        for (Authorization auth : auths) {
+            if (auth.grant(permission)) {
+                if (topic.match(auth.topic)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isNotEmpty(String client) {
+        return client != null && !client.isEmpty();
+    }
+
+    public boolean isEmpty() {
+        return m_globalAuthorizations.isEmpty();
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/security/DBAuthenticator.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/security/DBAuthenticator.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+import com.zaxxer.hikari.HikariDataSource;
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import org.apache.commons.codec.binary.Hex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Load user credentials from a SQL database. sql driver must be provided at runtime
+ */
+public class DBAuthenticator implements IAuthenticator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DBAuthenticator.class);
+
+    private final MessageDigest messageDigest;
+    private HikariDataSource dataSource;
+    private String sqlQuery;
+
+    public DBAuthenticator(IConfig conf) {
+        this(conf.getProperty(BrokerConstants.DB_AUTHENTICATOR_DRIVER, ""),
+             conf.getProperty(BrokerConstants.DB_AUTHENTICATOR_URL, ""),
+             conf.getProperty(BrokerConstants.DB_AUTHENTICATOR_QUERY, ""),
+             conf.getProperty(BrokerConstants.DB_AUTHENTICATOR_DIGEST, ""));
+    }
+
+    /**
+     * provide authenticator from SQL database
+     *
+     * @param driver
+     *            : jdbc driver class like : "org.postgresql.Driver"
+     * @param jdbcUrl
+     *            : jdbc url like : "jdbc:postgresql://host:port/dbname"
+     * @param sqlQuery
+     *            : sql query like : "SELECT PASSWORD FROM USER WHERE LOGIN=?"
+     * @param digestMethod
+     *            : password encoding algorithm : "MD5", "SHA-1", "SHA-256"
+     */
+    public DBAuthenticator(String driver, String jdbcUrl, String sqlQuery, String digestMethod) {
+        this.sqlQuery = sqlQuery;
+        this.dataSource = new HikariDataSource();
+        this.dataSource.setJdbcUrl(jdbcUrl);
+
+        try {
+            this.messageDigest = MessageDigest.getInstance(digestMethod);
+        } catch (NoSuchAlgorithmException nsaex) {
+            LOG.error(String.format("Can't find %s for password encoding", digestMethod), nsaex);
+            throw new RuntimeException(nsaex);
+        }
+    }
+
+    @Override
+    public synchronized boolean checkValid(String clientId, String username, byte[] password) {
+        // Check Username / Password in DB using sqlQuery
+        if (username == null || password == null) {
+            LOG.info("username or password was null");
+            return false;
+        }
+
+        ResultSet resultSet = null;
+        PreparedStatement preparedStatement = null;
+        Connection conn = null;
+        try {
+            conn = this.dataSource.getConnection();
+
+            preparedStatement = conn.prepareStatement(this.sqlQuery);
+            preparedStatement.setString(1, username);
+            resultSet = preparedStatement.executeQuery();
+            if (resultSet.next()) {
+                final String foundPwq = resultSet.getString(1);
+                messageDigest.update(password);
+                byte[] digest = messageDigest.digest();
+                String encodedPasswd = new String(Hex.encodeHex(digest));
+                return foundPwq.equals(encodedPasswd);
+            }
+        } catch (SQLException sqlex) {
+            LOG.error("Error quering DB for username: {}", username, sqlex);
+        } finally {
+            try {
+                if (resultSet != null) {
+                    resultSet.close();
+                }
+                if (preparedStatement != null) {
+                    preparedStatement.close();
+                }
+                if (conn != null) {
+                    conn.close();
+                }
+            } catch (SQLException e) {
+                LOG.error("Error releasing connection to the datasource", username, e);
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/security/DenyAllAuthorizatorPolicy.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/security/DenyAllAuthorizatorPolicy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+
+public class DenyAllAuthorizatorPolicy implements IAuthorizatorPolicy {
+
+    @Override
+    public boolean canRead(Topic topic, String user, String client) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Topic topic, String user, String client) {
+        return false;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/security/FileAuthenticator.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/security/FileAuthenticator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+import com.echostreams.pulsar.mqtt.broker.config.FileResourceLoader;
+
+/**
+ * Load user credentials from a text file. Each line of the file is formatted as
+ * "[username]:[sha256(password)]". The username mustn't contains : char.
+ *
+ * To encode your password from command line on Linux systems, you could use:
+ *
+ * <pre>
+ *     echo -n "yourpassword" | sha256sum
+ * </pre>
+ *
+ * NB -n is important because echo append a newline by default at the of string. -n avoid this
+ * behaviour.
+ *
+ * @deprecated user {@link ResourceAuthenticator} instead
+ */
+public class FileAuthenticator extends ResourceAuthenticator {
+
+    public FileAuthenticator(String parent, String filePath) {
+        super(new FileResourceLoader(parent), filePath);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/security/IAuthenticator.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/security/IAuthenticator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+/**
+ * username and password checker
+ */
+public interface IAuthenticator {
+
+    boolean checkValid(String clientId, String username, byte[] password);
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/security/IAuthorizatorPolicy.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/security/IAuthorizatorPolicy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+
+/**
+ * ACL checker.
+ *
+ * Create an authorizator that matches topic names with same grammar of subscriptions. The # is
+ * always a terminator and its the multilevel matcher. The + sign is the single level matcher.
+ */
+public interface IAuthorizatorPolicy {
+
+    /**
+     * Ask the implementation of the authorizator if the topic can be used in a publish.
+     *
+     * @param topic
+     *            the topic to write to.
+     * @param user
+     *            the user
+     * @param client
+     *            the client
+     * @return true if the user from client can publish data on topic.
+     */
+    boolean canWrite(Topic topic, String user, String client);
+
+    boolean canRead(Topic topic, String user, String client);
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/security/PermitAllAuthorizatorPolicy.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/security/PermitAllAuthorizatorPolicy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+
+public class PermitAllAuthorizatorPolicy implements IAuthorizatorPolicy {
+
+    @Override
+    public boolean canWrite(Topic topic, String user, String client) {
+        return true;
+    }
+
+    @Override
+    public boolean canRead(Topic topic, String user, String client) {
+        return true;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/security/ResourceAuthenticator.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/security/ResourceAuthenticator.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+import com.echostreams.pulsar.mqtt.broker.config.IResourceLoader;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Load user credentials from a text resource. Each line of the file is formatted as
+ * "[username]:[sha256(password)]". The username mustn't contains : char.
+ *
+ * To encode your password from command line on Linux systems, you could use:
+ *
+ * <pre>
+ *     echo -n "yourpassword" | sha256sum
+ * </pre>
+ *
+ * NB -n is important because echo append a newline by default at the of string. -n avoid this
+ * behaviour.
+ */
+public class ResourceAuthenticator implements IAuthenticator {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(ResourceAuthenticator.class);
+
+    private Map<String, String> m_identities = new HashMap<>();
+
+    public ResourceAuthenticator(IResourceLoader resourceLoader, String resourceName) {
+        try {
+            MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException nsaex) {
+            LOG.error("Can't find SHA-256 for password encoding", nsaex);
+            throw new RuntimeException(nsaex);
+        }
+
+        LOG.info(String.format("Loading password %s %s", resourceLoader.getName(), resourceName));
+        Reader reader = null;
+        try {
+            reader = resourceLoader.loadResource(resourceName);
+            if (reader == null) {
+                LOG.warn(String.format("Parsing not existing %s %s", resourceLoader.getName(), resourceName));
+            } else {
+                parse(reader);
+            }
+        } catch (IResourceLoader.ResourceIsDirectoryException e) {
+            LOG.warn(String.format("Trying to parse directory %s", resourceName));
+        } catch (ParseException pex) {
+            LOG.warn(
+                    String.format("Format error in parsing password %s %s", resourceLoader.getName(), resourceName),
+                    pex);
+        }
+    }
+
+    private void parse(Reader reader) throws ParseException {
+        if (reader == null) {
+            return;
+        }
+
+        BufferedReader br = new BufferedReader(reader);
+        String line;
+        try {
+            while ((line = br.readLine()) != null) {
+                int commentMarker = line.indexOf('#');
+                if (commentMarker != -1) {
+                    if (commentMarker == 0) {
+                        // skip its a comment
+                        continue;
+                    } else {
+                        // it's a malformed comment
+                        throw new ParseException(line, commentMarker);
+                    }
+                } else {
+                    if (line.isEmpty() || line.matches("^\\s*$")) {
+                        // skip it's a black line
+                        continue;
+                    }
+
+                    // split till the first space
+                    int delimiterIdx = line.indexOf(':');
+                    String username = line.substring(0, delimiterIdx).trim();
+                    String password = line.substring(delimiterIdx + 1).trim();
+
+                    m_identities.put(username, password);
+                }
+            }
+        } catch (IOException ex) {
+            throw new ParseException("Failed to read", 1);
+        }
+    }
+
+    @Override
+    public boolean checkValid(String clientId, String username, byte[] password) {
+        if (username == null || password == null) {
+            LOG.info("username or password was null");
+            return false;
+        }
+        String foundPwq = m_identities.get(username);
+        if (foundPwq == null) {
+            return false;
+        }
+        String encodedPasswd = DigestUtils.sha256Hex(password);
+        return foundPwq.equals(encodedPasswd);
+    }
+
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/CNode.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/CNode.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+import java.util.*;
+
+class CNode {
+
+    Token token;
+    private List<INode> children;
+    Set<Subscription> subscriptions;
+
+    CNode() {
+        this.children = new ArrayList<>();
+        this.subscriptions = new HashSet<>();
+    }
+
+    //Copy constructor
+    private CNode(Token token, List<INode> children, Set<Subscription> subscriptions) {
+        this.token = token; // keep reference, root comparison in directory logic relies on it for now.
+        this.subscriptions = new HashSet<>(subscriptions);
+        this.children = new ArrayList<>(children);
+    }
+
+    boolean anyChildrenMatch(Token token) {
+        for (INode iNode : children) {
+            final CNode child = iNode.mainNode();
+            if (child.equalsToken(token)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    List<INode> allChildren() {
+        return this.children;
+    }
+
+    INode childOf(Token token) {
+        for (INode iNode : children) {
+            final CNode child = iNode.mainNode();
+            if (child.equalsToken(token)) {
+                return iNode;
+            }
+        }
+        throw new IllegalArgumentException("Asked for a token that doesn't exists in any child [" + token + "]");
+    }
+
+    private boolean equalsToken(Token token) {
+        return token != null && this.token != null && this.token.equals(token);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(token);
+    }
+
+    CNode copy() {
+        return new CNode(this.token, this.children, this.subscriptions);
+    }
+
+    public void add(INode newINode) {
+        this.children.add(newINode);
+    }
+    public void remove(INode node) {
+        this.children.remove(node);
+    }
+
+    CNode addSubscription(Subscription newSubscription) {
+        // if already contains one with same topic and same client, keep that with higher QoS
+        if (subscriptions.contains(newSubscription)) {
+            final Subscription existing = subscriptions.stream()
+                .filter(s -> s.equals(newSubscription))
+                .findFirst().get();
+            if (existing.getRequestedQos().value() < newSubscription.getRequestedQos().value()) {
+                subscriptions.remove(existing);
+                subscriptions.add(new Subscription(newSubscription));
+            }
+        } else {
+            this.subscriptions.add(new Subscription(newSubscription));
+        }
+        return this;
+    }
+
+    /**
+     * @return true iff the subscriptions contained in this node are owned by clientId
+     *   AND at least one subscription is actually present for that clientId
+     * */
+    boolean containsOnly(String clientId) {
+        for (Subscription sub : this.subscriptions) {
+            if (!sub.clientId.equals(clientId)) {
+                return false;
+            }
+        }
+        return !this.subscriptions.isEmpty();
+    }
+
+    //TODO this is equivalent to negate(containsOnly(clientId))
+    public boolean contains(String clientId) {
+        for (Subscription sub : this.subscriptions) {
+            if (sub.clientId.equals(clientId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void removeSubscriptionsFor(String clientId) {
+        Set<Subscription> toRemove = new HashSet<>();
+        for (Subscription sub : this.subscriptions) {
+            if (sub.clientId.equals(clientId)) {
+                toRemove.add(sub);
+            }
+        }
+        this.subscriptions.removeAll(toRemove);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/CTrie.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/CTrie.java
@@ -1,0 +1,233 @@
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+public class CTrie {
+
+    interface IVisitor<T> {
+
+        void visit(CNode node, int deep);
+
+        T getResult();
+    }
+
+    private static final Token ROOT = new Token("root");
+    private static final INode NO_PARENT = null;
+
+    private enum Action {
+        OK, REPEAT
+    }
+
+    INode root;
+
+    CTrie() {
+        final CNode mainNode = new CNode();
+        mainNode.token = ROOT;
+        this.root = new INode(mainNode);
+    }
+
+    Optional<CNode> lookup(Topic topic) {
+        INode inode = this.root;
+        Token token = topic.headToken();
+        while (!topic.isEmpty() && (inode.mainNode().anyChildrenMatch(token))) {
+            topic = topic.exceptHeadToken();
+            inode = inode.mainNode().childOf(token);
+            token = topic.headToken();
+        }
+        if (inode == null || !topic.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(inode.mainNode());
+    }
+
+    enum NavigationAction {
+        MATCH, GODEEP, STOP
+    }
+
+    private NavigationAction evaluate(Topic topic, CNode cnode) {
+        if (Token.MULTI.equals(cnode.token)) {
+            return NavigationAction.MATCH;
+        }
+        if (topic.isEmpty()) {
+            return NavigationAction.STOP;
+        }
+        final Token token = topic.headToken();
+        if (!(Token.SINGLE.equals(cnode.token) || cnode.token.equals(token) || ROOT.equals(cnode.token))) {
+            return NavigationAction.STOP;
+        }
+        return NavigationAction.GODEEP;
+    }
+
+    public Set<Subscription> recursiveMatch(Topic topic) {
+        return recursiveMatch(topic, this.root);
+    }
+
+    private Set<Subscription> recursiveMatch(Topic topic, INode inode) {
+        CNode cnode = inode.mainNode();
+        NavigationAction action = evaluate(topic, cnode);
+        if (action == NavigationAction.MATCH) {
+            return cnode.subscriptions;
+        }
+        if (action == NavigationAction.STOP) {
+            return Collections.emptySet();
+        }
+        if (cnode instanceof TNode) {
+            return Collections.emptySet();
+        }
+        Topic remainingTopic = (ROOT.equals(cnode.token)) ? topic : topic.exceptHeadToken();
+        Set<Subscription> subscriptions = new HashSet<>();
+        if (remainingTopic.isEmpty()) {
+            subscriptions.addAll(cnode.subscriptions);
+        }
+        for (INode subInode : cnode.allChildren()) {
+            subscriptions.addAll(recursiveMatch(remainingTopic, subInode));
+        }
+        return subscriptions;
+    }
+
+    public void addToTree(Subscription newSubscription) {
+        Action res;
+        do {
+            res = insert(newSubscription.topicFilter, this.root, newSubscription);
+        } while (res == Action.REPEAT);
+    }
+
+    private Action insert(Topic topic, final INode inode, Subscription newSubscription) {
+        Token token = topic.headToken();
+        if (!topic.isEmpty() && inode.mainNode().anyChildrenMatch(token)) {
+            Topic remainingTopic = topic.exceptHeadToken();
+            INode nextInode = inode.mainNode().childOf(token);
+            return insert(remainingTopic, nextInode, newSubscription);
+        } else {
+            if (topic.isEmpty()) {
+                return insertSubscription(inode, newSubscription);
+            } else {
+                return createNodeAndInsertSubscription(topic, inode, newSubscription);
+            }
+        }
+    }
+
+    private Action insertSubscription(INode inode, Subscription newSubscription) {
+        CNode cnode = inode.mainNode();
+        CNode updatedCnode = cnode.copy().addSubscription(newSubscription);
+        if (inode.compareAndSet(cnode, updatedCnode)) {
+            return Action.OK;
+        } else {
+            return Action.REPEAT;
+        }
+    }
+
+    private Action createNodeAndInsertSubscription(Topic topic, INode inode, Subscription newSubscription) {
+        INode newInode = createPathRec(topic, newSubscription);
+        CNode cnode = inode.mainNode();
+        CNode updatedCnode = cnode.copy();
+        updatedCnode.add(newInode);
+
+        return inode.compareAndSet(cnode, updatedCnode) ? Action.OK : Action.REPEAT;
+    }
+
+    private INode createPathRec(Topic topic, Subscription newSubscription) {
+        Topic remainingTopic = topic.exceptHeadToken();
+        if (!remainingTopic.isEmpty()) {
+            INode inode = createPathRec(remainingTopic, newSubscription);
+            CNode cnode = new CNode();
+            cnode.token = topic.headToken();
+            cnode.add(inode);
+            return new INode(cnode);
+        } else {
+            return createLeafNodes(topic.headToken(), newSubscription);
+        }
+    }
+
+    private INode createLeafNodes(Token token, Subscription newSubscription) {
+        CNode newLeafCnode = new CNode();
+        newLeafCnode.token = token;
+        newLeafCnode.addSubscription(newSubscription);
+
+        return new INode(newLeafCnode);
+    }
+
+    public void removeFromTree(Topic topic, String clientID) {
+        Action res;
+        do {
+            res = remove(clientID, topic, this.root, NO_PARENT);
+        } while (res == Action.REPEAT);
+    }
+
+    private Action remove(String clientId, Topic topic, INode inode, INode iParent) {
+        Token token = topic.headToken();
+        if (!topic.isEmpty() && (inode.mainNode().anyChildrenMatch(token))) {
+            Topic remainingTopic = topic.exceptHeadToken();
+            INode nextInode = inode.mainNode().childOf(token);
+            return remove(clientId, remainingTopic, nextInode, inode);
+        } else {
+            final CNode cnode = inode.mainNode();
+            if (cnode instanceof TNode) {
+                // this inode is a tomb, has no clients and should be cleaned up
+                // Because we implemented cleanTomb below, this should be rare, but possible
+                // Consider calling cleanTomb here too
+                return Action.OK;
+            }
+            if (cnode.containsOnly(clientId) && topic.isEmpty() && cnode.allChildren().isEmpty()) {
+                // last client to leave this node, AND there are no downstream children, remove via TNode tomb
+                if (inode == this.root) {
+                    return inode.compareAndSet(cnode, inode.mainNode().copy()) ? Action.OK : Action.REPEAT;
+                }
+                TNode tnode = new TNode();
+                return inode.compareAndSet(cnode, tnode) ? cleanTomb(inode, iParent) : Action.REPEAT;
+            } else if (cnode.contains(clientId) && topic.isEmpty()) {
+                CNode updatedCnode = cnode.copy();
+                updatedCnode.removeSubscriptionsFor(clientId);
+                return inode.compareAndSet(cnode, updatedCnode) ? Action.OK : Action.REPEAT;
+            } else {
+                //someone else already removed
+                return Action.OK;
+            }
+        }
+    }
+
+    /**
+     *
+     * Cleans Disposes of TNode in separate Atomic CAS operation per
+     * http://bravenewgeek.com/breaking-and-entering-lose-the-lock-while-embracing-concurrency/
+     *
+     * We roughly follow this theory above, but we allow CNode with no Subscriptions to linger (for now).
+     *
+     *
+     * @param inode inode that handle to the tomb node.
+     * @param iParent inode parent.
+     * @return REPEAT if the this methods wasn't successful or OK.
+     */
+    private Action cleanTomb(INode inode, INode iParent) {
+        CNode updatedCnode = iParent.mainNode().copy();
+        updatedCnode.remove(inode);
+        return iParent.compareAndSet(iParent.mainNode(), updatedCnode) ? Action.OK : Action.REPEAT;
+    }
+
+    public int size() {
+        SubscriptionCounterVisitor visitor = new SubscriptionCounterVisitor();
+        dfsVisit(this.root, visitor, 0);
+        return visitor.getResult();
+    }
+
+    public String dumpTree() {
+        DumpTreeVisitor visitor = new DumpTreeVisitor();
+        dfsVisit(this.root, visitor, 0);
+        return visitor.getResult();
+    }
+
+    private void dfsVisit(INode node, IVisitor<?> visitor, int deep) {
+        if (node == null) {
+            return;
+        }
+
+        visitor.visit(node.mainNode(), deep);
+        ++deep;
+        for (INode child : node.mainNode().allChildren()) {
+            dfsVisit(child, visitor, deep);
+        }
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/CTrieSubscriptionDirectory.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/CTrieSubscriptionDirectory.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+import com.echostreams.pulsar.mqtt.broker.ISubscriptionsRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CTrieSubscriptionDirectory.class);
+
+    private CTrie ctrie;
+    private volatile ISubscriptionsRepository subscriptionsRepository;
+
+    @Override
+    public void init(ISubscriptionsRepository subscriptionsRepository) {
+        LOG.info("Initializing CTrie");
+        ctrie = new CTrie();
+
+        LOG.info("Initializing subscriptions store...");
+        this.subscriptionsRepository = subscriptionsRepository;
+        // reload any subscriptions persisted
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Reloading all stored subscriptions. SubscriptionTree = {}", dumpTree());
+        }
+
+        for (Subscription subscription : this.subscriptionsRepository.listAllSubscriptions()) {
+            LOG.debug("Re-subscribing {}", subscription);
+            ctrie.addToTree(subscription);
+        }
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Stored subscriptions have been reloaded. SubscriptionTree = {}", dumpTree());
+        }
+    }
+
+    Optional<CNode> lookup(Topic topic) {
+        return ctrie.lookup(topic);
+    }
+
+    /**
+     * Given a topic string return the clients subscriptions that matches it. Topic string can't
+     * contain character # and + because they are reserved to listeners subscriptions, and not topic
+     * publishing.
+     *
+     * @param topic
+     *            to use fo searching matching subscriptions.
+     * @return the list of matching subscriptions, or empty if not matching.
+     */
+    @Override
+    public Set<Subscription> matchWithoutQosSharpening(Topic topic) {
+        return ctrie.recursiveMatch(topic);
+    }
+
+    @Override
+    public Set<Subscription> matchQosSharpening(Topic topic) {
+        final Set<Subscription> subscriptions = matchWithoutQosSharpening(topic);
+
+        Map<String, Subscription> subsGroupedByClient = new HashMap<>();
+        for (Subscription sub : subscriptions) {
+            Subscription existingSub = subsGroupedByClient.get(sub.clientId);
+            // update the selected subscriptions if not present or if has a greater qos
+            if (existingSub == null || existingSub.qosLessThan(sub)) {
+                subsGroupedByClient.put(sub.clientId, sub);
+            }
+        }
+        return new HashSet<>(subsGroupedByClient.values());
+    }
+
+    @Override
+    public void add(Subscription newSubscription) {
+        ctrie.addToTree(newSubscription);
+        subscriptionsRepository.addNewSubscription(newSubscription);
+    }
+
+    /**
+     * Removes subscription from CTrie, adds TNode when the last client unsubscribes, then calls for cleanTomb in a
+     * separate atomic CAS operation.
+     *
+     * @param topic the subscription's topic to remove.
+     * @param clientID the Id of client owning the subscription.
+     */
+    @Override
+    public void removeSubscription(Topic topic, String clientID) {
+        ctrie.removeFromTree(topic, clientID);
+        this.subscriptionsRepository.removeSubscription(topic.toString(), clientID);
+    }
+
+    @Override
+    public int size() {
+        return ctrie.size();
+    }
+
+    @Override
+    public String dumpTree() {
+        return ctrie.dumpTree();
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/DumpTreeVisitor.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/DumpTreeVisitor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+import io.netty.util.internal.StringUtil;
+
+class DumpTreeVisitor implements CTrie.IVisitor<String> {
+
+    String s = "";
+
+    @Override
+    public void visit(CNode node, int deep) {
+        String indentTabs = indentTabs(deep);
+        s += indentTabs + (node.token == null ? "''" : node.token.toString()) + prettySubscriptions(node) + "\n";
+    }
+
+    private String prettySubscriptions(CNode node) {
+        if (node instanceof TNode) {
+            return "TNode";
+        }
+        if (node.subscriptions.isEmpty()) {
+            return StringUtil.EMPTY_STRING;
+        }
+        StringBuilder subScriptionsStr = new StringBuilder(" ~~[");
+        int counter = 0;
+        for (Subscription couple : node.subscriptions) {
+            subScriptionsStr
+                .append("{filter=").append(couple.topicFilter).append(", ")
+                .append("qos=").append(couple.getRequestedQos()).append(", ")
+                .append("client='").append(couple.clientId).append("'}");
+            counter++;
+            if (counter < node.subscriptions.size()) {
+                subScriptionsStr.append(";");
+            }
+        }
+        return subScriptionsStr.append("]").toString();
+    }
+
+    private String indentTabs(int deep) {
+        StringBuilder s = new StringBuilder();
+        if (deep > 0) {
+            s.append("    ");
+            for (int i = 0; i < deep - 1; i++) {
+                s.append("| ");
+            }
+            s.append("|-");
+        }
+        return s.toString();
+    }
+
+    @Override
+    public String getResult() {
+        return s;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/INode.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/INode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+class INode {
+    private AtomicReference<CNode> mainNode = new AtomicReference<>();
+
+    INode(CNode mainNode) {
+        this.mainNode.set(mainNode);
+        if (mainNode instanceof TNode) { // this should never happen
+            throw new IllegalStateException("TNode should not be set on mainNnode");
+        }
+    }
+
+    boolean compareAndSet(CNode old, CNode newNode) {
+        return mainNode.compareAndSet(old, newNode);
+    }
+
+    boolean compareAndSet(CNode old, TNode newNode) {
+        return mainNode.compareAndSet(old, newNode);
+    }
+
+    CNode mainNode() {
+        return this.mainNode.get();
+    }
+
+    boolean isTombed() {
+        return this.mainNode() instanceof TNode;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/ISubscriptionsDirectory.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/ISubscriptionsDirectory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+import com.echostreams.pulsar.mqtt.broker.ISubscriptionsRepository;
+
+import java.util.Set;
+
+public interface ISubscriptionsDirectory {
+
+    void init(ISubscriptionsRepository sessionsRepository);
+
+    Set<Subscription> matchWithoutQosSharpening(Topic topic);
+
+    Set<Subscription> matchQosSharpening(Topic topic);
+
+    void add(Subscription newSubscription);
+
+    void removeSubscription(Topic topic, String clientID);
+
+    int size();
+
+    String dumpTree();
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/Subscription.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/Subscription.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+import io.netty.handler.codec.mqtt.MqttQoS;
+
+import java.io.Serializable;
+
+/**
+ * Maintain the information about which Topic a certain ClientID is subscribed and at which QoS
+ */
+public final class Subscription implements Serializable {
+
+    private static final long serialVersionUID = -3383457629635732794L;
+    private final MqttQoS requestedQos; // max QoS acceptable
+    final String clientId;
+    final Topic topicFilter;
+
+    public Subscription(String clientId, Topic topicFilter, MqttQoS requestedQos) {
+        this.requestedQos = requestedQos;
+        this.clientId = clientId;
+        this.topicFilter = topicFilter;
+    }
+
+    public Subscription(Subscription orig) {
+        this.requestedQos = orig.requestedQos;
+        this.clientId = orig.clientId;
+        this.topicFilter = orig.topicFilter;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public MqttQoS getRequestedQos() {
+        return requestedQos;
+    }
+
+    public Topic getTopicFilter() {
+        return topicFilter;
+    }
+
+    public boolean qosLessThan(Subscription sub) {
+        return requestedQos.value() < sub.requestedQos.value();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        Subscription that = (Subscription) o;
+
+        if (clientId != null ? !clientId.equals(that.clientId) : that.clientId != null)
+            return false;
+        return !(topicFilter != null ? !topicFilter.equals(that.topicFilter) : that.topicFilter != null);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = clientId != null ? clientId.hashCode() : 0;
+        result = 31 * result + (topicFilter != null ? topicFilter.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("[filter:%s, clientID: %s, qos: %s]", topicFilter, clientId, requestedQos);
+    }
+
+    @Override
+    public Subscription clone() {
+        try {
+            return (Subscription) super.clone();
+        } catch (CloneNotSupportedException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/SubscriptionCounterVisitor.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/SubscriptionCounterVisitor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+class SubscriptionCounterVisitor implements CTrie.IVisitor<Integer> {
+
+    private AtomicInteger accumulator = new AtomicInteger(0);
+
+    @Override
+    public void visit(CNode node, int deep) {
+        accumulator.addAndGet(node.subscriptions.size());
+    }
+
+    @Override
+    public Integer getResult() {
+        return accumulator.get();
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/TNode.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/TNode.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+class TNode extends CNode {
+
+    @Override
+    INode childOf(Token token) {
+        throw new IllegalStateException("Can't be invoked on TNode");
+    }
+
+    @Override
+    CNode copy() {
+        throw new IllegalStateException("Can't be invoked on TNode");
+    }
+
+    @Override
+    public void add(INode newINode) {
+        throw new IllegalStateException("Can't be invoked on TNode");
+    }
+
+    @Override
+    CNode addSubscription(Subscription newSubscription) {
+        throw new IllegalStateException("Can't be invoked on TNode");
+    }
+
+    @Override
+    boolean containsOnly(String clientId) {
+        throw new IllegalStateException("Can't be invoked on TNode");
+    }
+
+    @Override
+    public boolean contains(String clientId) {
+        throw new IllegalStateException("Can't be invoked on TNode");
+    }
+
+    @Override
+    void removeSubscriptionsFor(String clientId) {
+        throw new IllegalStateException("Can't be invoked on TNode");
+    }
+
+    @Override
+    boolean anyChildrenMatch(Token token) {
+        return false;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/Token.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/Token.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+/**
+ * Internal use only class.
+ */
+public class Token {
+
+    static final Token EMPTY = new Token("");
+    static final Token MULTI = new Token("#");
+    static final Token SINGLE = new Token("+");
+    final String name;
+
+    protected Token(String s) {
+        name = s;
+    }
+
+    protected String name() {
+        return name;
+    }
+
+    protected boolean match(Token t) {
+        if (MULTI.equals(t) || SINGLE.equals(t)) {
+            return false;
+        }
+
+        if (MULTI.equals(this) || SINGLE.equals(this)) {
+            return true;
+        }
+
+        return equals(t);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 29 * hash + (this.name != null ? this.name.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Token other = (Token) obj;
+        if ((this.name == null) ? (other.name != null) : !this.name.equals(other.name)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/Topic.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/subscriptions/Topic.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+import java.io.Serializable;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Topic implements Serializable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Topic.class);
+
+    private static final long serialVersionUID = 2438799283749822L;
+
+    private final String topic;
+
+    private transient List<Token> tokens;
+
+    private transient boolean valid;
+
+    /**
+     * Factory method
+     *
+     * @param s the topic string (es "/a/b").
+     * @return the created Topic instance.
+     * */
+    public static Topic asTopic(String s) {
+        return new Topic(s);
+    }
+
+    public Topic(String topic) {
+        this.topic = topic;
+    }
+
+    Topic(List<Token> tokens) {
+        this.tokens = tokens;
+        List<String> strTokens = tokens.stream().map(Token::toString).collect(Collectors.toList());
+        this.topic = String.join("/", strTokens);
+        this.valid = true;
+    }
+
+    public List<Token> getTokens() {
+        if (tokens == null) {
+            try {
+                tokens = parseTopic(topic);
+                valid = true;
+            } catch (ParseException e) {
+                valid = false;
+                LOG.error("Error parsing the topic: {}, message: {}", topic, e.getMessage());
+            }
+        }
+
+        return tokens;
+    }
+
+    private List<Token> parseTopic(String topic) throws ParseException {
+        if (topic.length() == 0) {
+            throw new ParseException("Bad format of topic, topic MUST be at least 1 character [MQTT-4.7.3-1] and " +
+                                     "this was empty", 0);
+        }
+        List<Token> res = new ArrayList<>();
+        String[] splitted = topic.split("/");
+
+        if (splitted.length == 0) {
+            res.add(Token.EMPTY);
+        }
+
+        if (topic.endsWith("/")) {
+            // Add a fictious space
+            String[] newSplitted = new String[splitted.length + 1];
+            System.arraycopy(splitted, 0, newSplitted, 0, splitted.length);
+            newSplitted[splitted.length] = "";
+            splitted = newSplitted;
+        }
+
+        for (int i = 0; i < splitted.length; i++) {
+            String s = splitted[i];
+            if (s.isEmpty()) {
+                // if (i != 0) {
+                // throw new ParseException("Bad format of topic, expetec topic name between
+                // separators", i);
+                // }
+                res.add(Token.EMPTY);
+            } else if (s.equals("#")) {
+                // check that multi is the last symbol
+                if (i != splitted.length - 1) {
+                    throw new ParseException(
+                            "Bad format of topic, the multi symbol (#) has to be the last one after a separator",
+                            i);
+                }
+                res.add(Token.MULTI);
+            } else if (s.contains("#")) {
+                throw new ParseException("Bad format of topic, invalid subtopic name: " + s, i);
+            } else if (s.equals("+")) {
+                res.add(Token.SINGLE);
+            } else if (s.contains("+")) {
+                throw new ParseException("Bad format of topic, invalid subtopic name: " + s, i);
+            } else {
+                res.add(new Token(s));
+            }
+        }
+
+        return res;
+    }
+
+    public Token headToken() {
+        final List<Token> tokens = getTokens();
+        if (tokens.isEmpty()) {
+            //TODO UGLY use Optional
+            return null;
+        }
+        return tokens.get(0);
+    }
+
+    public boolean isEmpty() {
+        final List<Token> tokens = getTokens();
+        return tokens == null || tokens.isEmpty();
+    }
+
+    /**
+     * @return a new Topic corresponding to this less than the head token
+     * */
+    public Topic exceptHeadToken() {
+        List<Token> tokens = getTokens();
+        if (tokens.isEmpty()) {
+            return new Topic(Collections.emptyList());
+        }
+        List<Token> tokensCopy = new ArrayList<>(tokens);
+        tokensCopy.remove(0);
+        return new Topic(tokensCopy);
+    }
+
+    public boolean isValid() {
+        if (tokens == null)
+            getTokens();
+
+        return valid;
+    }
+
+    /**
+     * Verify if the 2 topics matching respecting the rules of MQTT Appendix A
+     *
+     * @param subscriptionTopic
+     *            the topic filter of the subscription
+     * @return true if the two topics match.
+     */
+    // TODO reimplement with iterators or with queues
+    public boolean match(Topic subscriptionTopic) {
+        List<Token> msgTokens = getTokens();
+        List<Token> subscriptionTokens = subscriptionTopic.getTokens();
+        int i = 0;
+        for (; i < subscriptionTokens.size(); i++) {
+            Token subToken = subscriptionTokens.get(i);
+            if (!Token.MULTI.equals(subToken) && !Token.SINGLE.equals(subToken)) {
+                if (i >= msgTokens.size()) {
+                    return false;
+                }
+                Token msgToken = msgTokens.get(i);
+                if (!msgToken.equals(subToken)) {
+                    return false;
+                }
+            } else {
+                if (Token.MULTI.equals(subToken)) {
+                    return true;
+                }
+//                if (Token.SINGLE.equals(subToken)) {
+//                    // skip a step forward
+//                }
+            }
+        }
+        return i == msgTokens.size();
+    }
+
+    @Override
+    public String toString() {
+        return topic;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Topic other = (Topic) obj;
+
+        return Objects.equals(this.topic, other.topic);
+    }
+
+    @Override
+    public int hashCode() {
+        return topic.hashCode();
+    }
+
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/utils/CommonUtils.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/utils/CommonUtils.java
@@ -1,0 +1,26 @@
+package com.echostreams.pulsar.mqtt.broker.utils;
+
+import org.h2.util.StringUtils;
+
+public class CommonUtils {
+
+    /**
+     * Create topic prefix like this persistent://my-tenant/my-namespace/my-topic
+     * @param persistentName
+     * @param tenantName
+     * @param namespaceName
+     * @param topicName
+     * @return
+     */
+    public static String createTopicNameWithPrefix(String persistentName, String tenantName, String namespaceName,
+                                                   String topicName) {
+        String topicNameWithPrefix = persistentName+"://"+tenantName+"/"+namespaceName;
+
+        if(StringUtils.isNullOrEmpty(topicName))
+            return topicNameWithPrefix;
+        else if("/".contains(topicName))
+            return topicNameWithPrefix + topicName;
+        else
+            return topicNameWithPrefix + "/"+topicName;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/utils/CommonUtils.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/utils/CommonUtils.java
@@ -1,26 +1,22 @@
 package com.echostreams.pulsar.mqtt.broker.utils;
 
-import org.h2.util.StringUtils;
-
 public class CommonUtils {
 
+    private CommonUtils() {
+    }
+
     /**
-     * Create topic prefix like this persistent://my-tenant/my-namespace/my-topic
-     * @param persistentName
-     * @param tenantName
-     * @param namespaceName
-     * @param topicName
+     * It validates one or more objects for nullity
+     *
+     * @param objects
      * @return
      */
-    public static String createTopicNameWithPrefix(String persistentName, String tenantName, String namespaceName,
-                                                   String topicName) {
-        String topicNameWithPrefix = persistentName+"://"+tenantName+"/"+namespaceName;
-
-        if(StringUtils.isNullOrEmpty(topicName))
-            return topicNameWithPrefix;
-        else if("/".contains(topicName))
-            return topicNameWithPrefix + topicName;
-        else
-            return topicNameWithPrefix + "/"+topicName;
+    public static boolean isAnyObjectNull(Object... objects) {
+        for (Object o : objects) {
+            if (o == null) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/utils/DebugUtils.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/utils/DebugUtils.java
@@ -14,7 +14,7 @@
  * You may elect to redistribute this code under either of these licenses.
  */
 
-package com.echostreams.pulsar.mqtt.broker;
+package com.echostreams.pulsar.mqtt.broker.utils;
 
 import io.netty.buffer.ByteBuf;
 

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/utils/NettyUtils.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/utils/NettyUtils.java
@@ -14,15 +14,15 @@
  * You may elect to redistribute this code under either of these licenses.
  */
 
-package com.echostreams.pulsar.mqtt.broker;
-
-import java.io.IOException;
+package com.echostreams.pulsar.mqtt.broker.utils;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
+
+import java.io.IOException;
 
 /**
  * Some Netty's channels utilities.

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/utils/TopicUtils.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/utils/TopicUtils.java
@@ -1,0 +1,86 @@
+package com.echostreams.pulsar.mqtt.broker.utils;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import org.h2.util.StringUtils;
+
+import java.util.regex.Pattern;
+
+public class TopicUtils {
+
+    private TopicUtils() {
+    }
+
+    /**
+     * Create topic prefix like this persistent://my-tenant/my-namespace/my-topic
+     *
+     * @param topicPrefix
+     * @param topicName
+     * @return
+     */
+    public static String createTopicWithPrefix(String topicPrefix,
+                                               String topicName) {
+
+        if (StringUtils.isNullOrEmpty(topicName))
+            return topicPrefix;
+        else if ("/".contains(topicName))
+            return topicPrefix + topicName;
+        else
+            return topicPrefix + "/" + topicName;
+    }
+
+    /**
+     * Create a new topic prefix for the given persistentName, tenantName, namespaceName
+     *
+     * @param persistentName
+     * @param tenantName
+     * @param namespaceName
+     * @return
+     */
+    public static String createOnlyPrefixWithoutTopic(String persistentName, String tenantName, String namespaceName) {
+        return persistentName + BrokerConstants.DOUBLE_FORWARD_SLASH + tenantName + BrokerConstants.SINGLE_FORWARD_SLASH + namespaceName;
+
+    }
+
+    /**
+     * Updating BrokerConstants.PULSAR_TOPIC_NAME_PREFIX value if defined in config file
+     *
+     * @param persistentName
+     * @param tenantName
+     * @param namespaceName
+     */
+    public static void createOnlyPrefixWithConfigValues(String persistentName, String tenantName, String namespaceName) {
+        if (!CommonUtils.isAnyObjectNull(persistentName, tenantName, namespaceName))
+            BrokerConstants.PULSAR_TOPIC_NAME_PREFIX = persistentName + BrokerConstants.DOUBLE_FORWARD_SLASH + tenantName + BrokerConstants.SINGLE_FORWARD_SLASH + namespaceName;
+    }
+
+    // Create topic prefix with value given in config file
+    public static String getDefaultPrefixWithoutTopic() {
+        return BrokerConstants.PERSISTENT_NAME + BrokerConstants.DOUBLE_FORWARD_SLASH + BrokerConstants.TENANT_NAME +
+                BrokerConstants.SINGLE_FORWARD_SLASH + BrokerConstants.NAMESPACE_NAME;
+
+    }
+
+    /**
+     * Validate topic string against regular expression i.e. pattern
+     * defined in config file and return true/false
+     *
+     * @param topic
+     * @return
+     */
+    public static boolean matchTopicWithPattern(String topic) {
+        return Pattern.matches(BrokerConstants.TOPIC_PROCESSING_IDENTIFIER, topic);
+    }
+
+    /**
+     * Return true if message storage type  is persistent or non-persistent in config file,
+     * else returns false
+     *
+     * @param messageStorageType
+     * @return
+     */
+    public static boolean isValidMessageStorageTypeName(String messageStorageType) {
+        return BrokerConstants.PERSISTENT_NAME.equals(messageStorageType)
+                || BrokerConstants.NON_PERSISTENT_NAME.equals(messageStorageType);
+    }
+
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/broker/utils/Utils.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/broker/utils/Utils.java
@@ -14,7 +14,7 @@
  * You may elect to redistribute this code under either of these licenses.
  */
 
-package com.echostreams.pulsar.mqtt.broker;
+package com.echostreams.pulsar.mqtt.broker.utils;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.mqtt.MqttMessage;

--- a/src/main/java/com/echostreams/pulsar/mqtt/interception/AbstractInterceptHandler.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/interception/AbstractInterceptHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception;
+
+import com.echostreams.pulsar.mqtt.interception.messages.InterceptAcknowledgedMessage;
+import com.echostreams.pulsar.mqtt.interception.messages.InterceptConnectMessage;
+import com.echostreams.pulsar.mqtt.interception.messages.InterceptConnectionLostMessage;
+import com.echostreams.pulsar.mqtt.interception.messages.InterceptDisconnectMessage;
+import com.echostreams.pulsar.mqtt.interception.messages.InterceptPublishMessage;
+import com.echostreams.pulsar.mqtt.interception.messages.InterceptSubscribeMessage;
+import com.echostreams.pulsar.mqtt.interception.messages.InterceptUnsubscribeMessage;
+
+/**
+ * Basic abstract class usefull to avoid empty methods creation in subclasses.
+ */
+public abstract class AbstractInterceptHandler implements InterceptHandler {
+
+    @Override
+    public Class<?>[] getInterceptedMessageTypes() {
+        return ALL_MESSAGE_TYPES;
+    }
+
+    @Override
+    public void onConnect(InterceptConnectMessage msg) {
+    }
+
+    @Override
+    public void onDisconnect(InterceptDisconnectMessage msg) {
+    }
+
+    @Override
+    public void onConnectionLost(InterceptConnectionLostMessage msg) {
+    }
+
+    @Override
+    public void onPublish(InterceptPublishMessage msg) {
+    }
+
+    @Override
+    public void onSubscribe(InterceptSubscribeMessage msg) {
+    }
+
+    @Override
+    public void onUnsubscribe(InterceptUnsubscribeMessage msg) {
+    }
+
+    @Override
+    public void onMessageAcknowledged(InterceptAcknowledgedMessage msg) {
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/interception/BrokerInterceptor.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/interception/BrokerInterceptor.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+import com.echostreams.pulsar.mqtt.interception.messages.*;
+import com.echostreams.pulsar.mqtt.logging.LoggingUtils;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.util.ReferenceCountUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An interceptor that execute the interception tasks asynchronously.
+ */
+public final class BrokerInterceptor implements Interceptor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BrokerInterceptor.class);
+    private final Map<Class<?>, List<InterceptHandler>> handlers;
+    private final ExecutorService executor;
+
+    private BrokerInterceptor(int poolSize, List<InterceptHandler> handlers) {
+        LOG.info("Initializing broker interceptor. InterceptorIds={}", LoggingUtils.getInterceptorIds(handlers));
+        this.handlers = new HashMap<>();
+        for (Class<?> messageType : InterceptHandler.ALL_MESSAGE_TYPES) {
+            this.handlers.put(messageType, new CopyOnWriteArrayList<InterceptHandler>());
+        }
+        for (InterceptHandler handler : handlers) {
+            this.addInterceptHandler(handler);
+        }
+        executor = Executors.newFixedThreadPool(poolSize);
+    }
+
+    /**
+     * Configures a broker interceptor, with a thread pool of one thread.
+     *
+     * @param handlers InterceptHandlers listeners.
+     */
+    public BrokerInterceptor(List<InterceptHandler> handlers) {
+        this(1, handlers);
+    }
+
+    /**
+     * Configures a broker interceptor using the pool size specified in the IConfig argument.
+     * @param props configuration properties.
+     * @param handlers InterceptHandlers listeners.
+     *
+     */
+    public BrokerInterceptor(IConfig props, List<InterceptHandler> handlers) {
+        this(Integer.parseInt(props.getProperty(BrokerConstants.BROKER_INTERCEPTOR_THREAD_POOL_SIZE, "1")), handlers);
+    }
+
+    /**
+     * Shutdown graciously the executor service
+     */
+    void stop() {
+        LOG.info("Shutting down interceptor thread pool...");
+        executor.shutdown();
+        try {
+            LOG.info("Waiting for thread pool tasks to terminate...");
+            executor.awaitTermination(10L, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+        }
+        if (!executor.isTerminated()) {
+            LOG.warn("Forcing shutdown of interceptor thread pool...");
+            executor.shutdownNow();
+        }
+        LOG.info("interceptors stopped");
+    }
+
+    @Override
+    public void notifyClientConnected(final MqttConnectMessage msg) {
+        for (final InterceptHandler handler : this.handlers.get(InterceptConnectMessage.class)) {
+            LOG.debug("Sending MQTT CONNECT message to interceptor. CId={}, interceptorId={}",
+                    msg.payload().clientIdentifier(), handler.getID());
+            executor.execute(() -> handler.onConnect(new InterceptConnectMessage(msg)));
+        }
+    }
+
+    @Override
+    public void notifyClientDisconnected(final String clientID, final String username) {
+        for (final InterceptHandler handler : this.handlers.get(InterceptDisconnectMessage.class)) {
+            LOG.debug("Notifying MQTT client disconnection to interceptor. CId={}, username={}, interceptorId={}",
+                clientID, username, handler.getID());
+            executor.execute(() -> handler.onDisconnect(new InterceptDisconnectMessage(clientID, username)));
+        }
+    }
+
+    @Override
+    public void notifyClientConnectionLost(final String clientID, final String username) {
+        for (final InterceptHandler handler : this.handlers.get(InterceptConnectionLostMessage.class)) {
+            LOG.debug("Notifying unexpected MQTT client disconnection to interceptor CId={}, username={}, " +
+                "interceptorId={}", clientID, username, handler.getID());
+            executor.execute(() -> handler.onConnectionLost(new InterceptConnectionLostMessage(clientID, username)));
+        }
+    }
+
+    @Override
+    public void notifyTopicPublished(final MqttPublishMessage msg, final String clientID, final String username) {
+        msg.retain();
+
+        executor.execute(() -> {
+                try {
+                    int messageId = msg.variableHeader().messageId();
+                    String topic = msg.variableHeader().topicName();
+                    for (InterceptHandler handler : handlers.get(InterceptPublishMessage.class)) {
+                        LOG.debug("Notifying MQTT PUBLISH message to interceptor. CId={}, messageId={}, topic={}, "
+                                + "interceptorId={}", clientID, messageId, topic, handler.getID());
+                        handler.onPublish(new InterceptPublishMessage(msg, clientID, username));
+                    }
+                } finally {
+                    ReferenceCountUtil.release(msg);
+                }
+        });
+    }
+
+    @Override
+    public void notifyTopicSubscribed(final Subscription sub, final String username) {
+        for (final InterceptHandler handler : this.handlers.get(InterceptSubscribeMessage.class)) {
+            LOG.debug("Notifying MQTT SUBSCRIBE message to interceptor. CId={}, topicFilter={}, interceptorId={}",
+                sub.getClientId(), sub.getTopicFilter(), handler.getID());
+            executor.execute(() -> handler.onSubscribe(new InterceptSubscribeMessage(sub, username)));
+        }
+    }
+
+    @Override
+    public void notifyTopicUnsubscribed(final String topic, final String clientID, final String username) {
+        for (final InterceptHandler handler : this.handlers.get(InterceptUnsubscribeMessage.class)) {
+            LOG.debug("Notifying MQTT UNSUBSCRIBE message to interceptor. CId={}, topic={}, interceptorId={}", clientID,
+                topic, handler.getID());
+            executor.execute(() -> handler.onUnsubscribe(new InterceptUnsubscribeMessage(topic, clientID, username)));
+        }
+    }
+
+    @Override
+    public void notifyMessageAcknowledged(final InterceptAcknowledgedMessage msg) {
+        for (final InterceptHandler handler : this.handlers.get(InterceptAcknowledgedMessage.class)) {
+            LOG.debug("Notifying MQTT ACK message to interceptor. CId={}, messageId={}, topic={}, interceptorId={}",
+                msg.getMsg()/*.getClientID()*/, msg.getPacketID(), msg.getTopic(), handler.getID());
+            executor.execute(() -> handler.onMessageAcknowledged(msg));
+        }
+    }
+
+    @Override
+    public void addInterceptHandler(InterceptHandler interceptHandler) {
+        Class<?>[] interceptedMessageTypes = getInterceptedMessageTypes(interceptHandler);
+        LOG.info("Adding MQTT message interceptor. InterceptorId={}, handledMessageTypes={}",
+            interceptHandler.getID(), interceptedMessageTypes);
+        for (Class<?> interceptMessageType : interceptedMessageTypes) {
+            this.handlers.get(interceptMessageType).add(interceptHandler);
+        }
+    }
+
+    @Override
+    public void removeInterceptHandler(InterceptHandler interceptHandler) {
+        Class<?>[] interceptedMessageTypes = getInterceptedMessageTypes(interceptHandler);
+        LOG.info("Removing MQTT message interceptor. InterceptorId={}, handledMessageTypes={}",
+            interceptHandler.getID(), interceptedMessageTypes);
+        for (Class<?> interceptMessageType : interceptedMessageTypes) {
+            this.handlers.get(interceptMessageType).remove(interceptHandler);
+        }
+    }
+
+    private static Class<?>[] getInterceptedMessageTypes(InterceptHandler interceptHandler) {
+        Class<?>[] interceptedMessageTypes = interceptHandler.getInterceptedMessageTypes();
+        if (interceptedMessageTypes == null) {
+            return InterceptHandler.ALL_MESSAGE_TYPES;
+        }
+        return interceptedMessageTypes;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/interception/InterceptHandler.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/interception/InterceptHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+import com.echostreams.pulsar.mqtt.interception.messages.*;
+import io.netty.handler.codec.mqtt.MqttMessage;
+
+/**
+ * This interface is used to inject code for intercepting broker events.
+ * <p>
+ * The events can act only as observers.
+ * <p>
+ * Almost every method receives a subclass of {@link MqttMessage}, except <code>onDisconnect</code>
+ * that receives the client id string and <code>onSubscribe</code> and <code>onUnsubscribe</code>
+ * that receive a {@link Subscription} object.
+ */
+public interface InterceptHandler {
+
+    Class<?>[] ALL_MESSAGE_TYPES = {InterceptConnectMessage.class, InterceptDisconnectMessage.class,
+            InterceptConnectionLostMessage.class, InterceptPublishMessage.class, InterceptSubscribeMessage.class,
+            InterceptUnsubscribeMessage.class, InterceptAcknowledgedMessage.class};
+
+    /**
+     * @return the identifier of this intercept handler.
+     */
+    String getID();
+
+    /**
+     * @return the InterceptMessage subtypes that this handler can process. If the result is null or
+     * equal to ALL_MESSAGE_TYPES, all the message types will be processed.
+     */
+    Class<?>[] getInterceptedMessageTypes();
+
+    void onConnect(InterceptConnectMessage msg);
+
+    void onDisconnect(InterceptDisconnectMessage msg);
+
+    void onConnectionLost(InterceptConnectionLostMessage msg);
+
+    void onPublish(InterceptPublishMessage msg);
+
+    void onSubscribe(InterceptSubscribeMessage msg);
+
+    void onUnsubscribe(InterceptUnsubscribeMessage msg);
+
+    void onMessageAcknowledged(InterceptAcknowledgedMessage msg);
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/interception/Interceptor.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/interception/Interceptor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+import com.echostreams.pulsar.mqtt.interception.messages.InterceptAcknowledgedMessage;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+
+/**
+ * This interface is to be used internally by the broker components.
+ * <p>
+ * An interface is used instead of a class to allow more flexibility in changing an implementation.
+ * <p>
+ * Interceptor implementations forward notifications to a <code>InterceptHandler</code>, that is
+ * normally a field. So, the implementations should act as a proxy to a custom intercept handler.
+ *
+ * @see InterceptHandler
+ */
+public interface Interceptor {
+
+    void notifyClientConnected(MqttConnectMessage msg);
+
+    void notifyClientDisconnected(String clientID, String username);
+
+    void notifyClientConnectionLost(String clientID, String username);
+
+    void notifyTopicPublished(MqttPublishMessage msg, String clientID, String username);
+
+    void notifyTopicSubscribed(Subscription sub, String username);
+
+    void notifyTopicUnsubscribed(String topic, String clientID, String username);
+
+    void notifyMessageAcknowledged(InterceptAcknowledgedMessage msg);
+
+    void addInterceptHandler(InterceptHandler interceptHandler);
+
+    void removeInterceptHandler(InterceptHandler interceptHandler);
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptAbstractMessage.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptAbstractMessage.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception.messages;
+
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
+
+public abstract class InterceptAbstractMessage implements InterceptMessage {
+
+    private final MqttMessage msg;
+
+    InterceptAbstractMessage(MqttMessage msg) {
+        this.msg = msg;
+    }
+
+    public boolean isRetainFlag() {
+        return msg.fixedHeader().isRetain();
+    }
+
+    public boolean isDupFlag() {
+        return msg.fixedHeader().isDup();
+    }
+
+    public MqttQoS getQos() {
+        return msg.fixedHeader().qosLevel();
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptAcknowledgedMessage.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptAcknowledgedMessage.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception.messages;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttQoS;
+
+import java.io.Serializable;
+
+public class InterceptAcknowledgedMessage implements InterceptMessage {
+
+    class StoredMessage implements Serializable {
+
+        private static final long serialVersionUID = 1755296138639817304L;
+        private MqttQoS m_qos;
+        final byte[] m_payload;
+        final String m_topic;
+        private boolean m_retained;
+        private String m_clientID;
+
+        public StoredMessage(byte[] message, MqttQoS qos, String topic) {
+            m_qos = qos;
+            m_payload = message;
+            m_topic = topic;
+        }
+
+        public void setQos(MqttQoS qos) {
+            this.m_qos = qos;
+        }
+
+        public MqttQoS getQos() {
+            return m_qos;
+        }
+
+        public String getTopic() {
+            return m_topic;
+        }
+
+        public String getClientID() {
+            return m_clientID;
+        }
+
+        public void setClientID(String m_clientID) {
+            this.m_clientID = m_clientID;
+        }
+
+        public ByteBuf getPayload() {
+            return Unpooled.copiedBuffer(m_payload);
+        }
+
+        public void setRetained(boolean retained) {
+            this.m_retained = retained;
+        }
+
+        public boolean isRetained() {
+            return m_retained;
+        }
+
+        @Override
+        public String toString() {
+            return "PublishEvent{clientID='" + m_clientID + '\'' + ", m_retain="
+                + m_retained + ", m_qos=" + m_qos + ", m_topic='" + m_topic + '\'' + '}';
+        }
+    }
+
+    private final StoredMessage msg;
+    private final String username;
+    private final String topic;
+    private final int packetID;
+
+    public InterceptAcknowledgedMessage(StoredMessage msg, String topic, String username, int packetID) {
+        this.msg = msg;
+        this.username = username;
+        this.topic = topic;
+        this.packetID = packetID;
+    }
+
+    public StoredMessage getMsg() {
+        return msg;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public int getPacketID() {
+        return packetID;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptConnectMessage.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptConnectMessage.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception.messages;
+
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+
+import java.nio.charset.StandardCharsets;
+
+public class InterceptConnectMessage extends InterceptAbstractMessage {
+
+    private final MqttConnectMessage msg;
+
+    public InterceptConnectMessage(MqttConnectMessage msg) {
+        super(msg);
+        this.msg = msg;
+    }
+
+    public String getClientID() {
+        return msg.payload().clientIdentifier();
+    }
+
+    public boolean isCleanSession() {
+        return msg.variableHeader().isCleanSession();
+    }
+
+    public int getKeepAlive() {
+        return msg.variableHeader().keepAliveTimeSeconds();
+    }
+
+    public boolean isPasswordFlag() {
+        return msg.variableHeader().hasPassword();
+    }
+
+    public byte getProtocolVersion() {
+        return (byte) msg.variableHeader().version();
+    }
+
+    public String getProtocolName() {
+        return msg.variableHeader().name();
+    }
+
+    public boolean isUserFlag() {
+        return msg.variableHeader().hasUserName();
+    }
+
+    public boolean isWillFlag() {
+        return msg.variableHeader().isWillFlag();
+    }
+
+    public byte getWillQos() {
+        return (byte) msg.variableHeader().willQos();
+    }
+
+    public boolean isWillRetain() {
+        return msg.variableHeader().isWillRetain();
+    }
+
+    public String getUsername() {
+        return msg.payload().userName();
+    }
+
+    public byte[] getPassword() {
+        return msg.payload().password().getBytes(StandardCharsets.UTF_8);
+    }
+
+    public String getWillTopic() {
+        return msg.payload().willTopic();
+    }
+
+    public byte[] getWillMessage() {
+        return msg.payload().willMessage().getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptConnectionLostMessage.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptConnectionLostMessage.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception.messages;
+
+public class InterceptConnectionLostMessage implements InterceptMessage {
+
+    private final String clientID;
+    private final String username;
+
+    public InterceptConnectionLostMessage(String clientID, String username) {
+        this.clientID = clientID;
+        this.username = username;
+    }
+
+    public String getClientID() {
+        return clientID;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptDisconnectMessage.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptDisconnectMessage.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception.messages;
+
+public class InterceptDisconnectMessage implements InterceptMessage {
+
+    private final String clientID;
+    private final String username;
+
+    public InterceptDisconnectMessage(String clientID, String username) {
+        this.clientID = clientID;
+        this.username = username;
+    }
+
+    public String getClientID() {
+        return clientID;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptMessage.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptMessage.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception.messages;
+
+/**
+ * An interface that sets the root of the interceptor messages type hierarchy.
+ */
+public interface InterceptMessage {
+
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptPublishMessage.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptPublishMessage.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception.messages;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+
+public class InterceptPublishMessage extends InterceptAbstractMessage {
+
+    private final MqttPublishMessage msg;
+    private final String clientID;
+    private final String username;
+
+    public InterceptPublishMessage(MqttPublishMessage msg, String clientID, String username) {
+        super(msg);
+        this.msg = msg;
+        this.clientID = clientID;
+        this.username = username;
+    }
+
+    public String getTopicName() {
+        return msg.variableHeader().topicName();
+    }
+
+    public ByteBuf getPayload() {
+        return msg.payload();
+    }
+
+    public String getClientID() {
+        return clientID;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptSubscribeMessage.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptSubscribeMessage.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception.messages;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+import io.netty.handler.codec.mqtt.MqttQoS;
+
+public class InterceptSubscribeMessage implements InterceptMessage {
+
+    private final Subscription subscription;
+    private final String username;
+
+    public InterceptSubscribeMessage(Subscription subscription, String username) {
+        this.subscription = subscription;
+        this.username = username;
+    }
+
+    public String getClientID() {
+        return subscription.getClientId();
+    }
+
+    public MqttQoS getRequestedQos() {
+        return subscription.getRequestedQos();
+    }
+
+    public String getTopicFilter() {
+        return subscription.getTopicFilter().toString();
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptUnsubscribeMessage.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/interception/messages/InterceptUnsubscribeMessage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception.messages;
+
+public class InterceptUnsubscribeMessage implements InterceptMessage {
+
+    private final String topicFilter;
+    private final String clientID;
+    private final String username;
+
+    public InterceptUnsubscribeMessage(String topicFilter, String clientID, String username) {
+        this.topicFilter = topicFilter;
+        this.clientID = clientID;
+        this.username = username;
+    }
+
+    public String getTopicFilter() {
+        return topicFilter;
+    }
+
+    public String getClientID() {
+        return clientID;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/logging/LoggingUtils.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/logging/LoggingUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.logging;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import com.echostreams.pulsar.mqtt.interception.InterceptHandler;
+
+public final class LoggingUtils {
+
+    public static <T extends InterceptHandler> Collection<String> getInterceptorIds(Collection<T> handlers) {
+        Collection<String> result = new ArrayList<>(handlers.size());
+        for (T handler : handlers) {
+            result.add(handler.getID());
+        }
+        return result;
+    }
+
+    private LoggingUtils() {
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/persistence/H2Builder.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/persistence/H2Builder.java
@@ -1,0 +1,65 @@
+package com.echostreams.pulsar.mqtt.persistence;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.IQueueRepository;
+import com.echostreams.pulsar.mqtt.broker.IRetainedRepository;
+import com.echostreams.pulsar.mqtt.broker.ISubscriptionsRepository;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import org.h2.mvstore.MVStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class H2Builder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(H2Builder.class);
+
+    private final String storePath;
+    private final int autosaveInterval; // in seconds
+    private final ScheduledExecutorService scheduler;
+    private MVStore mvStore;
+
+    public H2Builder(IConfig props, ScheduledExecutorService scheduler) {
+        this.storePath = props.getProperty(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME, "");
+        final String autosaveProp = props.getProperty(BrokerConstants.AUTOSAVE_INTERVAL_PROPERTY_NAME, "30");
+        this.autosaveInterval = Integer.parseInt(autosaveProp);
+        this.scheduler = scheduler;
+    }
+
+    @SuppressWarnings("FutureReturnValueIgnored")
+    public H2Builder initStore() {
+        LOG.info("Initializing H2 store");
+        if (storePath == null || storePath.isEmpty()) {
+            throw new IllegalArgumentException("H2 store path can't be null or empty");
+        }
+        mvStore = new MVStore.Builder()
+            .fileName(storePath)
+            .autoCommitDisabled()
+            .open();
+
+        LOG.trace("Scheduling H2 commit task");
+        scheduler.scheduleWithFixedDelay(() -> {
+            LOG.trace("Committing to H2");
+            mvStore.commit();
+        }, autosaveInterval, autosaveInterval, TimeUnit.SECONDS);
+        return this;
+    }
+
+    public ISubscriptionsRepository subscriptionsRepository() {
+        return new H2SubscriptionsRepository(mvStore);
+    }
+
+    public void closeStore() {
+        mvStore.close();
+    }
+
+    public IQueueRepository queueRepository() {
+        return new H2QueueRepository(mvStore);
+    }
+
+    public IRetainedRepository retainedRepository() {
+        return new H2RetainedRepository(mvStore);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/persistence/H2PersistentQueue.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/persistence/H2PersistentQueue.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.persistence;
+
+import org.h2.mvstore.MVMap;
+import org.h2.mvstore.MVStore;
+
+import java.util.AbstractQueue;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLong;
+
+class H2PersistentQueue<T> extends AbstractQueue<T> {
+
+    private final MVMap<Long, T> queueMap;
+    private final MVMap<String, Long> metadataMap;
+    private final AtomicLong head;
+    private final AtomicLong tail;
+
+    H2PersistentQueue(MVStore store, String queueName) {
+        if (queueName == null || queueName.isEmpty()) {
+            throw new IllegalArgumentException("queueName parameter can't be empty or null");
+        }
+        this.queueMap = store.openMap("queue_" + queueName);
+        this.metadataMap = store.openMap("queue_" + queueName + "_meta");
+
+        //setup head index
+        long headIdx = 0L;
+        if (this.metadataMap.containsKey("head")) {
+            headIdx = this.metadataMap.get("head");
+        } else {
+            this.metadataMap.put("head", headIdx);
+        }
+        this.head = new AtomicLong(headIdx);
+
+        //setup tail index
+        long tailIdx = 0L;
+        if (this.metadataMap.containsKey("tail")) {
+            tailIdx = this.metadataMap.get("tail");
+        } else {
+            this.metadataMap.put("tail", tailIdx);
+        }
+        this.tail = new AtomicLong(tailIdx);
+    }
+
+    static void dropQueue(MVStore store, String queueName) {
+        store.removeMap(store.openMap("queue_" + queueName));
+        store.removeMap(store.openMap("queue_" + queueName + "_meta"));
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return null;
+    }
+
+    @Override
+    public int size() {
+        return this.head.intValue() - this.tail.intValue();
+    }
+
+    @Override
+    public boolean offer(T t) {
+        if (t == null) {
+            throw new NullPointerException("Inserted element can't be null");
+        }
+        final long nextHead = head.getAndIncrement();
+        this.queueMap.put(nextHead, t);
+        this.metadataMap.put("head", nextHead + 1);
+        return true;
+    }
+
+    @Override
+    public T poll() {
+        if (head.equals(tail)) {
+            return null;
+        }
+        final long nextTail = tail.getAndIncrement();
+        final T tail = this.queueMap.get(nextTail);
+        queueMap.remove(nextTail);
+        this.metadataMap.put("tail", nextTail + 1);
+        return tail;
+    }
+
+    @Override
+    public T peek() {
+        if (head.equals(tail)) {
+            return null;
+        }
+        return this.queueMap.get(tail.get());
+    }
+
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/persistence/H2QueueRepository.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/persistence/H2QueueRepository.java
@@ -1,0 +1,25 @@
+package com.echostreams.pulsar.mqtt.persistence;
+
+import com.echostreams.pulsar.mqtt.broker.IQueueRepository;
+import com.echostreams.pulsar.mqtt.broker.SessionRegistry;
+import org.h2.mvstore.MVStore;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class H2QueueRepository implements IQueueRepository {
+
+    private MVStore mvStore;
+
+    public H2QueueRepository(MVStore mvStore) {
+        this.mvStore = mvStore;
+    }
+
+    @Override
+    public Queue<SessionRegistry.EnqueuedMessage> createQueue(String cli, boolean clean) {
+        if (!clean) {
+            return new H2PersistentQueue<>(mvStore, cli);
+        }
+        return new ConcurrentLinkedQueue<>();
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/persistence/H2RetainedRepository.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/persistence/H2RetainedRepository.java
@@ -1,0 +1,55 @@
+package com.echostreams.pulsar.mqtt.persistence;
+
+import com.echostreams.pulsar.mqtt.broker.RetainedMessage;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import com.echostreams.pulsar.mqtt.broker.IRetainedRepository;
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import org.h2.mvstore.MVMap;
+import org.h2.mvstore.MVStore;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class H2RetainedRepository implements IRetainedRepository {
+
+    private final MVMap<Topic, RetainedMessage> queueMap;
+
+    public H2RetainedRepository(MVStore mvStore) {
+        this.queueMap = mvStore.openMap("retained_store");
+    }
+
+    @Override
+    public void cleanRetained(Topic topic) {
+        queueMap.remove(topic);
+    }
+
+    @Override
+    public void retain(Topic topic, MqttPublishMessage msg) {
+        final ByteBuf payload = msg.content();
+        byte[] rawPayload = new byte[payload.readableBytes()];
+        payload.getBytes(0, rawPayload);
+        final RetainedMessage toStore = new RetainedMessage(msg.fixedHeader().qosLevel(), rawPayload);
+        queueMap.put(topic, toStore);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return queueMap.isEmpty();
+    }
+
+    @Override
+    public List<RetainedMessage> retainedOnTopic(String topic) {
+        final Topic searchTopic = new Topic(topic);
+        final List<RetainedMessage> matchingMessages = new ArrayList<>();
+        for (Map.Entry<Topic, RetainedMessage> entry : queueMap.entrySet()) {
+            final Topic scanTopic = entry.getKey();
+            if (searchTopic.match(scanTopic)) {
+                matchingMessages.add(entry.getValue());
+            }
+        }
+
+        return matchingMessages;
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/persistence/H2SubscriptionsRepository.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/persistence/H2SubscriptionsRepository.java
@@ -1,0 +1,48 @@
+package com.echostreams.pulsar.mqtt.persistence;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+import com.echostreams.pulsar.mqtt.broker.ISubscriptionsRepository;
+import org.h2.mvstore.Cursor;
+import org.h2.mvstore.MVMap;
+import org.h2.mvstore.MVStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class H2SubscriptionsRepository implements ISubscriptionsRepository {
+
+    private static final Logger LOG = LoggerFactory.getLogger(H2SubscriptionsRepository.class);
+    private static final String SUBSCRIPTIONS_MAP = "subscriptions";
+
+    private MVMap<String, Subscription> subscriptions;
+
+    H2SubscriptionsRepository(MVStore mvStore) {
+        this.subscriptions = mvStore.openMap(SUBSCRIPTIONS_MAP);
+    }
+
+    @Override
+    public List<Subscription> listAllSubscriptions() {
+        LOG.debug("Retrieving existing subscriptions");
+
+        List<Subscription> results = new ArrayList<>();
+        Cursor<String, Subscription> mapCursor = subscriptions.cursor(null);
+        while (mapCursor.hasNext()) {
+            String subscriptionStr = mapCursor.next();
+            results.add(mapCursor.getValue());
+        }
+        LOG.debug("Loaded {} subscriptions", results.size());
+        return results;
+    }
+
+    @Override
+    public void addNewSubscription(Subscription subscription) {
+        subscriptions.put(subscription.getTopicFilter() + "-" + subscription.getClientId(), subscription);
+    }
+
+    @Override
+    public void removeSubscription(String topicFilter, String clientID) {
+        subscriptions.remove(topicFilter + "-" + clientID);
+    }
+}

--- a/src/main/java/com/echostreams/pulsar/mqtt/persistence/MemorySubscriptionsRepository.java
+++ b/src/main/java/com/echostreams/pulsar/mqtt/persistence/MemorySubscriptionsRepository.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.persistence;
+
+import com.echostreams.pulsar.mqtt.broker.ISubscriptionsRepository;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class MemorySubscriptionsRepository implements ISubscriptionsRepository {
+
+    private final List<Subscription> subscriptions = new ArrayList<>();
+
+    @Override
+    public List<Subscription> listAllSubscriptions() {
+        return Collections.unmodifiableList(subscriptions);
+    }
+
+    @Override
+    public void addNewSubscription(Subscription subscription) {
+        subscriptions.add(subscription);
+    }
+
+    @Override
+    public void removeSubscription(String topic, String clientID) {
+        subscriptions.stream()
+            .filter(s -> s.getTopicFilter().toString().equals(topic) && s.getClientId().equals(clientID))
+            .findFirst()
+            .ifPresent(subscriptions::remove);
+    }
+}

--- a/src/main/resources/acl.conf
+++ b/src/main/resources/acl.conf
@@ -1,0 +1,5 @@
+#*********************************************
+# ACL Format:
+#   topic [read|write|readwrite] <topic name>
+#*********************************************
+topic write /sensors/anemometer

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,16 +5,29 @@
 ##############################################
 
 #*********************************************************************
-# persistent: message storage type
-#
-#tenant: tenant name
-#
-#namespace: default namespace name
+# pulsar_service_url : To connect pulsar server
 #*********************************************************************
 
-persistent persistent
-tenant my-tenant
-namespace my-namespace
+pulsar_service_url pulsar://localhost:6650
+
+#*********************************************************************
+# topic_processing_identifier : regular expressions
+#       String pattern to validate the topic
+#*********************************************************************
+
+topic_processing_identifier [a-zA-Z]
+
+#*********************************************************************
+# message_storage_type: persistent OR non-persistent
+#
+#tenant_value: tenant name
+#
+#namespace_value: default namespace name
+#*********************************************************************
+
+message_storage_type persistent
+tenant_name my-tenant
+namespace_name my-namespace
 
 #*********************************************************************
 # TCP MQTT TRAFFIC
@@ -103,7 +116,7 @@ password_file config/password_file.conf
 
 
 #*********************************************************************
-# Optional Database Authentication
+ # Optional Database Authentication
 #*********************************************************************
 # authenticator_class DBAuthenticator
 # authenticator.db.driver org.postgresql.Driver

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,18 +1,178 @@
 
-#mqtt traffic unencrytped(tcp), encrypted(ssl), both(ssl_tcp)
-mqtt.traffic=tcp
+##############################################
+#  pulsar-mqtt-provider configuration file.
+#
+##############################################
 
-#default port
-port=1883
+#*********************************************************************
+# persistent: message storage type
+#
+#tenant: tenant name
+#
+#namespace: default namespace name
+#*********************************************************************
 
-#ssl default port
-ssl.port=8883
+persistent persistent
+tenant my-tenant
+namespace my-namespace
 
-#message storage
-persistence=
+#*********************************************************************
+# TCP MQTT TRAFFIC
+#  port:
+#
+#  websocket_port:
+#*********************************************************************
+port 1883
+websocket_port 8080
 
-#default tenant name
-tenant=my-tenant
+#*********************************************************************
+#false to prohibit clients from connecting without a clientid.
+#true to allow clients to connect without a clientid. One will be generated for them.
+#*********************************************************************
+allow_zero_byte_client_id false
 
-#default namespace name
-namespace=my-namespace
+#*********************************************************************
+# Secure Websocket port (wss)
+# decommend this to enable wss
+#*********************************************************************
+secure_websocket_port 8883
+
+#*********************************************************************
+# SSL tcp part
+#  ssl_provider: defines the SSL implementation to use, default to "JDK"
+#            supported values are "JDK", "OPENSSL" and "OPENSSL_REFCNT"
+#            By choosing one of the OpenSSL implementations the crypto
+#            operations will be performed by a native Open SSL library.
+#
+#  jks_path: define the file that contains the Java Key Store,
+#            relative to the current broker home
+#
+#  key_store_type: defines the key store container type, default to "jks"
+#            supported values are "jceks", "jks" and "pkcs12"
+#            The "jceks" and "jks" key stores are a propietary SUN
+#            implementations. "pkcs12" is defined in PKCS#12 standard.
+#
+#  key_store_password: is the password used to open the keystore
+#
+#  key_manager_password: is the password used to manage the alias in the
+#            keystore
+#*********************************************************************
+
+#ssl_provider JDK
+#ssl_port=8883
+#jks_path serverkeystore.jks
+#key_store_type jks
+#key_store_password passw0rdsrv
+key_manager_password passw0rdsrv
+
+#*********************************************************************
+# The interface to bind the server
+#  0.0.0.0 means "any"
+#*********************************************************************
+host 0.0.0.0
+
+#*********************************************************************
+# The file for the persistent store, if not specified, use just memory
+# no physical persistence
+#*********************************************************************
+#persistent_store ./moquette_store.h2
+
+#*********************************************************************
+# acl_file:
+#    defines the path to the ACL file relative to moquette home dir
+#    contained in the moquette.path system property
+#*********************************************************************
+#acl_file config/acl.conf
+
+#*********************************************************************
+# allow_anonymous is used to accept MQTT connections also from not
+# authenticated clients.
+#   - false to accept ONLY client connetions with credentials.
+#   - true to accept client connection without credentails, validating
+#       only against the password_file, the ones that provides.
+#*********************************************************************
+allow_anonymous true
+
+#*********************************************************************
+# password_file:
+#    defines the path to the file that contains the credentials for
+#    authenticated client connection. It's relative to moquette home dir
+#    defined by the system property moquette.path
+#*********************************************************************
+password_file config/password_file.conf
+
+
+#*********************************************************************
+# Optional Database Authentication
+#*********************************************************************
+# authenticator_class DBAuthenticator
+# authenticator.db.driver org.postgresql.Driver
+# authenticator.db.url jdbc:postgresql://localhost/test?user=dbuser&password=dbpassword
+# authenticator.db.query SELECT PASSWORD FROM ACCOUNT WHERE LOGIN=?
+# authenticator.db.digest SHA-256
+
+#*********************************************************************
+# Optional
+# authorizator_class:
+#      class name of the authorizator, by default uses the
+#      password_file.conf.
+#      If not specified uses the class: AuthorizationsCollector
+#
+# Optional
+# authenticator_class:
+#      class name of the authenticator, default implementation uses
+#      definitions in the acl.conf.
+#      If not specified uses FileAuthenticator
+# Optional
+# reauthorize_subscriptions_on_connect:
+#		true to force the validation of authorizations of existing
+#		subscriptions when the client reconnects with not clean session
+#*********************************************************************
+# authenticator_class [[path to your class>]]
+# authorizator_class [[path to your class>]]
+# reauthorize_subscriptions_on_connect true|false
+
+
+#*********************************************************************
+# Persistence configuration
+# autosave_interval:
+#       interval between flushes of MapDB storage to disk. It's in
+#       seconds, if not specified defaults is 30 s.
+#*********************************************************************
+# autosave_interval 120
+
+#*********************************************************************
+# Netty Configuration
+#
+# netty.epoll: Linux systems can use epoll instead of nio. To get a performance
+# gain and reduced GC.
+# http://netty.io/wiki/native-transports.html for more information
+# netty.mqtt.message_size : by default the max size of message is set at 8092 bytes
+# http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os-complete.html#_Toc442180836
+# Fore more information about payload size specs.
+#*********************************************************************
+# netty.epoll true
+# netty.mqtt.message_size 8092
+
+#*********************************************************************
+# Metrics Configuration
+#
+# use_metrics: used to enable Dropwizard Metrics sampling metrics.
+# metrics.librato.email: Librato account's email
+# metrics.librato.token: Librato account's security token
+# metrics.librato.source: your application as source in Librato
+#       definitions
+#*********************************************************************
+# use_metrics true
+# metrics.librato.email john@doe.com
+# metrics.librato.token sdfergheghliuhyr2283ehd9827398h
+# metrics.librato.source My Fantastic Service
+
+#*********************************************************************
+# Error Monitoring
+#
+# use_bugsnag: used to enable BugSnag error handler catcher.
+# bugsnag.token: the token from your's bugsnag account
+#*********************************************************************
+# use_bugsnag false
+# bugsnag.token wleifb8723784dbfeig74

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,8 +26,8 @@ topic_processing_identifier [a-zA-Z]
 #*********************************************************************
 
 message_storage_type persistent
-tenant_name my-tenant
-namespace_name my-namespace
+tenant_name public
+namespace_name default
 
 #*********************************************************************
 # TCP MQTT TRAFFIC

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,18 @@
+
+#mqtt traffic unencrytped(tcp), encrypted(ssl), both(ssl_tcp)
+mqtt.traffic=tcp
+
+#default port
+port=1883
+
+#ssl default port
+ssl.port=8883
+
+#message storage
+persistence=
+
+#default tenant name
+tenant=my-tenant
+
+#default namespace name
+namespace=my-namespace

--- a/src/main/resources/assembly.xml
+++ b/src/main/resources/assembly.xml
@@ -16,9 +16,10 @@
                 <include>acl.conf</include>
                 <include>password_file.conf</include>
                 <include>logback.xml</include>
-                <include>pulsarMqttProvider.sh</include>
-                <include>pulsarMqttProvider.bat</include>
+                <include>startApp.sh</include>
+                <include>startApp.bat</include>
             </includes>
+            <lineEnding>unix</lineEnding>
         </fileSet>
     </fileSets>
     <dependencySets>

--- a/src/main/resources/assembly.xml
+++ b/src/main/resources/assembly.xml
@@ -1,0 +1,40 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>bin</id>
+
+    <formats>
+        <format>tar.gz</format>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>src/main/resources/</directory>
+            <outputDirectory/>
+            <includes>
+                <include>application.properties</include>
+                <include>logback.xml</include>
+                <include>pulsarMqttProvider.sh</include>
+                <include>pulsarMqttProvider.bat</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <unpack>false</unpack>
+            <scope>runtime</scope>
+            <excludes>
+                <exclude>pulsar-mqtt-provider*</exclude>
+            </excludes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <unpack>false</unpack>
+            <scope>runtime</scope>
+            <includes>
+                <include>pulsar-mqtt-provider*</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/src/main/resources/assembly.xml
+++ b/src/main/resources/assembly.xml
@@ -13,6 +13,8 @@
             <outputDirectory/>
             <includes>
                 <include>application.properties</include>
+                <include>acl.conf</include>
+                <include>password_file.conf</include>
                 <include>logback.xml</include>
                 <include>pulsarMqttProvider.sh</include>
                 <include>pulsarMqttProvider.bat</include>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <jmxConfigurator/>
+
+    <!-- Stop output INFO at start -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
+    <property name="LOGS" value="./logs"/>
+
+    <appender name="Console"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %black(%d{ISO8601}) %highlight(%-5level) [%blue(%t)] %yellow(%C{1.}): %msg%n%throwable
+            </Pattern>
+        </layout>
+    </appender>
+
+    <appender name="RollingFile"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOGS}/pulsar-mqtt-provider.log</file>
+        <encoder
+                class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
+        </encoder>
+
+        <rollingPolicy
+                class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- rollover daily and when the file reaches 10 MegaBytes -->
+            <fileNamePattern>${LOGS}/archived/pulsar-mqtt-provider-%d{yyyy-MM-dd}.%i.log
+            </fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy
+                    class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+        </rollingPolicy>
+    </appender>
+
+    <!-- LOG "org.apache.pulsar" at ERROR level
+    <logger name="org.apache.pulsar" level="error" additivity="false">
+           <appender-ref ref="RollingFile" />
+           <appender-ref ref="Console" />
+    </logger>
+    -->
+
+    <!-- LOG everything at INFO level -->
+    <root level="info">
+        <appender-ref ref="RollingFile"/>
+        <appender-ref ref="Console"/>
+    </root>
+
+
+</configuration>

--- a/src/main/resources/password_file.conf
+++ b/src/main/resources/password_file.conf
@@ -1,0 +1,6 @@
+#*********************************************
+# Each line define a user login in the format
+#   <username>:sha256(<password>)
+#*********************************************
+#NB this password is sha256(passwd)
+testuser:0d6be69b264717f2dd33652e212b173104b4a647b7c11ae72e9885f11cd312fb

--- a/src/main/resources/pulsarMqttProvider.bat
+++ b/src/main/resources/pulsarMqttProvider.bat
@@ -1,0 +1,88 @@
+@ECHO OFF
+rem #
+rem # Copyright (c) 2012-2015 Andrea Selva
+rem #
+
+echo "                                                                         "
+echo "  ___  ___                       _   _        ___  ________ _____ _____  "
+echo "  |  \/  |                      | | | |       |  \/  |  _  |_   _|_   _| "
+echo "  | .  . | ___   __ _ _   _  ___| |_| |_ ___  | .  . | | | | | |   | |   "
+echo "  | |\/| |/ _ \ / _\ | | | |/ _ \ __| __/ _ \ | |\/| | | | | | |   | |   "
+echo "  | |  | | (_) | (_| | |_| |  __/ |_| ||  __/ | |  | \ \/' / | |   | |   "
+echo "  \_|  |_/\___/ \__, |\__,_|\___|\__|\__\___| \_|  |_/\_/\_\ \_/   \_/   "
+echo "                   | |                                                   "
+echo "                   |_|                                                   "
+echo "                                                                         "
+echo "                                               version: 0.13-SNAPSHOT    "
+
+set "CURRENT_DIR=%cd%"
+if not "%MOQUETTE_HOME%" == "" goto gotHome
+set "MOQUETTE_HOME=%CURRENT_DIR%"
+if exist "%MOQUETTE_HOME%\bin\moquette.bat" goto okHome
+cd ..
+set "MOQUETTE_HOME=%cd%"
+cd "%CURRENT_DIR%"
+:gotHome
+if exist "%MOQUETTE_HOME%\bin\moquette.bat" goto okHome
+    echo The MOQUETTE_HOME environment variable is not defined correctly
+    echo This environment variable is needed to run this program
+goto end
+:okHome
+
+rem Set JavaHome if it exists
+if exist { "%JAVA_HOME%\bin\java" } (
+    set JAVA="%JAVA_HOME%\bin\java"
+)
+
+echo Using JAVA_HOME:       "%JAVA_HOME%"
+echo Using MOQUETTE_HOME:   "%MOQUETTE_HOME%"
+
+rem  set LOG_CONSOLE_LEVEL=info
+rem  set LOG_FILE_LEVEL=fine
+set JAVA_OPTS=
+set JAVA_OPTS_SCRIPT=-XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true
+set MOQUETTE_PATH=%MOQUETTE_HOME%
+set LOG_FILE=%MOQUETTE_HOME%\config\moquette-log.properties
+
+rem # Use the Hotspot garbage-first collector.
+set JAVA_OPTS=%JAVA_OPTS%  -XX:+UseG1GC
+
+rem # Have the JVM do less remembered set work during STW, instead
+rem # preferring concurrent GC. Reduces p99.9 latency.
+set JAVA_OPTS=%JAVA_OPTS%  -XX:G1RSetUpdatingPauseTimePercent=5
+
+rem # Main G1GC tunable: lowering the pause target will lower throughput and vise versa.
+rem # 200ms is the JVM default and lowest viable setting
+rem # 1000ms increases throughput. Keep it smaller than the timeouts.
+set JAVA_OPTS=%JAVA_OPTS%  -XX:MaxGCPauseMillis=500
+
+rem # Optional G1 Settings
+
+rem  Save CPU time on large (>= 16GB) heaps by delaying region scanning
+rem  until the heap is 70% full. The default in Hotspot 8u40 is 40%.
+rem set JAVA_OPTS=%JAVA_OPTS%  -XX:InitiatingHeapOccupancyPercent=70
+
+rem  For systems with > 8 cores, the default ParallelGCThreads is 5/8 the number of logical cores.
+rem  Otherwise equal to the number of cores when 8 or less.
+rem  Machines with > 10 cores should try setting these to <= full cores.
+rem set JAVA_OPTS=%JAVA_OPTS%  -XX:ParallelGCThreads=16
+
+rem  By default, ConcGCThreads is 1/4 of ParallelGCThreads.
+rem  Setting both to the same value can reduce STW durations.
+rem set JAVA_OPTS=%JAVA_OPTS%  -XX:ConcGCThreads=16
+
+rem ## GC logging options -- uncomment to enable
+
+set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintGCDetails
+set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintGCDateStamps
+set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintHeapAtGC
+set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintTenuringDistribution
+set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintGCApplicationStoppedTime
+set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintPromotionFailure
+rem set JAVA_OPTS=%JAVA_OPTS% -XX:PrintFLSStatistics=1
+rem set JAVA_OPTS=%JAVA_OPTS% -Xloggc:/var/log/moquette/gc.log
+set JAVA_OPTS=%JAVA_OPTS% -XX:+UseGCLogFileRotation
+set JAVA_OPTS=%JAVA_OPTS% -XX:NumberOfGCLogFiles=10
+set JAVA_OPTS=%JAVA_OPTS% -XX:GCLogFileSize=10M
+
+%JAVA% -server %JAVA_OPTS% %JAVA_OPTS_SCRIPT% -Dlog4j.configuration=file:%LOG_FILE% -Dmoquette.path=%MOQUETTE_PATH% -cp %MOQUETTE_HOME%\lib\* Server

--- a/src/main/resources/pulsarMqttProvider.bat
+++ b/src/main/resources/pulsarMqttProvider.bat
@@ -85,4 +85,4 @@ set JAVA_OPTS=%JAVA_OPTS% -XX:+UseGCLogFileRotation
 set JAVA_OPTS=%JAVA_OPTS% -XX:NumberOfGCLogFiles=10
 set JAVA_OPTS=%JAVA_OPTS% -XX:GCLogFileSize=10M
 
-%JAVA% -server %JAVA_OPTS% %JAVA_OPTS_SCRIPT% -Dlog4j.configuration=file:%LOG_FILE% -Dmoquette.path=%MOQUETTE_PATH% -cp %MOQUETTE_HOME%\lib\* Server
+%JAVA% -server %JAVA_OPTS% %JAVA_OPTS_SCRIPT% -Dmoquette.path=%MOQUETTE_PATH% -cp %MOQUETTE_HOME%\lib\* Server

--- a/src/main/resources/pulsarMqttProvider.sh
+++ b/src/main/resources/pulsarMqttProvider.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+#
+# Copyright (c) 2012-2015 Andrea Selva
+#
+
+echo "                                                                         "
+echo "  ___  ___                       _   _        ___  ________ _____ _____  "
+echo "  |  \/  |                      | | | |       |  \/  |  _  |_   _|_   _| "
+echo "  | .  . | ___   __ _ _   _  ___| |_| |_ ___  | .  . | | | | | |   | |   "
+echo "  | |\/| |/ _ \ / _\ | | | |/ _ \ __| __/ _ \ | |\/| | | | | | |   | |   "
+echo "  | |  | | (_) | (_| | |_| |  __/ |_| ||  __/ | |  | \ \/' / | |   | |   "
+echo "  \_|  |_/\___/ \__, |\__,_|\___|\__|\__\___| \_|  |_/\_/\_\ \_/   \_/   "
+echo "                   | |                                                   "
+echo "                   |_|                                                   "
+echo "                                                                         "
+echo "                                               version: 0..13-SNAPSHOT   "
+
+
+cd "$(dirname "$0")"
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set MOQUETTE_HOME if not already set
+[ -f "$MOQUETTE_HOME"/bin/moquette.sh ] || MOQUETTE_HOME=`cd "$PRGDIR/.." ; pwd`
+export MOQUETTE_HOME
+
+# Set JavaHome if it exists
+if [ -f "${JAVA_HOME}/bin/java" ]; then 
+   JAVA=${JAVA_HOME}/bin/java
+else
+   JAVA=java
+fi
+export JAVA
+
+LOG_FILE=$MOQUETTE_HOME/config/moquette-log.properties
+MOQUETTE_PATH=$MOQUETTE_HOME/
+#LOG_CONSOLE_LEVEL=info
+#LOG_FILE_LEVEL=fine
+JAVA_OPTS_SCRIPT="-XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true"
+
+## Use the Hotspot garbage-first collector.
+JAVA_OPTS="$JAVA_OPTS -XX:+UseG1GC"
+
+## Have the JVM do less remembered set work during STW, instead
+## preferring concurrent GC. Reduces p99.9 latency.
+JAVA_OPTS="$JAVA_OPTS -XX:G1RSetUpdatingPauseTimePercent=5"
+
+## Main G1GC tunable: lowering the pause target will lower throughput and vise versa.
+## 200ms is the JVM default and lowest viable setting
+## 1000ms increases throughput. Keep it smaller than the timeouts.
+JAVA_OPTS="$JAVA_OPTS -XX:MaxGCPauseMillis=500"
+
+## Optional G1 Settings
+
+# Save CPU time on large (>= 16GB) heaps by delaying region scanning
+# until the heap is 70% full. The default in Hotspot 8u40 is 40%.
+#JAVA_OPTS="$JAVA_OPTS -XX:InitiatingHeapOccupancyPercent=70"
+
+# For systems with > 8 cores, the default ParallelGCThreads is 5/8 the number of logical cores.
+# Otherwise equal to the number of cores when 8 or less.
+# Machines with > 10 cores should try setting these to <= full cores.
+#JAVA_OPTS="$JAVA_OPTS -XX:ParallelGCThreads=16"
+
+# By default, ConcGCThreads is 1/4 of ParallelGCThreads.
+# Setting both to the same value can reduce STW durations.
+#JAVA_OPTS="$JAVA_OPTS -XX:ConcGCThreads=16"
+
+### GC logging options -- uncomment to enable
+
+JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCDetails"
+JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCDateStamps"
+JAVA_OPTS="$JAVA_OPTS -XX:+PrintHeapAtGC"
+JAVA_OPTS="$JAVA_OPTS -XX:+PrintTenuringDistribution"
+JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCApplicationStoppedTime"
+JAVA_OPTS="$JAVA_OPTS -XX:+PrintPromotionFailure"
+#JAVA_OPTS="$JAVA_OPTS -XX:PrintFLSStatistics=1"
+#JAVA_OPTS="$JAVA_OPTS -Xloggc:/var/log/moquette/gc.log"
+JAVA_OPTS="$JAVA_OPTS -Xloggc:$MOQUETTE_HOME/gc.log"
+JAVA_OPTS="$JAVA_OPTS -XX:+UseGCLogFileRotation"
+JAVA_OPTS="$JAVA_OPTS -XX:NumberOfGCLogFiles=10"
+JAVA_OPTS="$JAVA_OPTS -XX:GCLogFileSize=10M"
+
+$JAVA -server $JAVA_OPTS $JAVA_OPTS_SCRIPT -Dlog4j.configuration="file:$LOG_FILE" -Dmoquette.path="$MOQUETTE_PATH" -cp "$MOQUETTE_HOME/lib/*" Server

--- a/src/main/resources/startApp.bat
+++ b/src/main/resources/startApp.bat
@@ -1,32 +1,31 @@
 @ECHO OFF
 rem #
-rem # Copyright (c) 2012-2015 Andrea Selva
+rem # Copyright (c) 2019 Quinovas
 rem #
 
-echo "                                                                         "
-echo "  ___  ___                       _   _        ___  ________ _____ _____  "
-echo "  |  \/  |                      | | | |       |  \/  |  _  |_   _|_   _| "
-echo "  | .  . | ___   __ _ _   _  ___| |_| |_ ___  | .  . | | | | | |   | |   "
-echo "  | |\/| |/ _ \ / _\ | | | |/ _ \ __| __/ _ \ | |\/| | | | | | |   | |   "
-echo "  | |  | | (_) | (_| | |_| |  __/ |_| ||  __/ | |  | \ \/' / | |   | |   "
-echo "  \_|  |_/\___/ \__, |\__,_|\___|\__|\__\___| \_|  |_/\_/\_\ \_/   \_/   "
-echo "                   | |                                                   "
-echo "                   |_|                                                   "
-echo "                                                                         "
-echo "                                               version: 0.13-SNAPSHOT    "
+echo "                                                                          "
+echo "  ______      _                 ___  ________ _____ _____                 "
+echo "  | ___ \    | |                |  \/  |  _  |_   _|_   _|                "
+echo "  | |_/ /   _| |___  __ _ _ __  | .  . | | | | | |   | |                  "
+echo "  |  __/ | | | / __|/ _  | '__| | |\/| | | | | | |   | |                  "
+echo "  | |  | |_| | \__ \ (_| | |    | |  | \ \/' / | |   | |                  "
+echo "  \_|   \__,_|_|___/\__,_|_|    \_|  |_/\_/\_\ \_/   \_/                  "
+echo "										                               "
+echo "                                 version: 1.0-SNAPSHOT   			        "
+echo "										                                    "
 
-set "CURRENT_DIR=%cd%"
-if not "%MOQUETTE_HOME%" == "" goto gotHome
-set "MOQUETTE_HOME=%CURRENT_DIR%"
-if exist "%MOQUETTE_HOME%\bin\moquette.bat" goto okHome
-cd ..
-set "MOQUETTE_HOME=%cd%"
-cd "%CURRENT_DIR%"
+
+set "PULSAR_MQTT_PATH=%cd%"
+
+if not "%PULSAR_MQTT_PATH%" == "" goto gotHome
+if exist "%PULSAR_MQTT_PATH%\startApp.bat" goto okHome
+
 :gotHome
-if exist "%MOQUETTE_HOME%\bin\moquette.bat" goto okHome
-    echo The MOQUETTE_HOME environment variable is not defined correctly
+if exist "%PULSAR_MQTT_PATH%\startApp.bat" goto okHome
+    echo The PULSAR_MQTT_PATH environment variable is not defined correctly
     echo This environment variable is needed to run this program
 goto end
+
 :okHome
 
 rem Set JavaHome if it exists
@@ -35,14 +34,14 @@ if exist { "%JAVA_HOME%\bin\java" } (
 )
 
 echo Using JAVA_HOME:       "%JAVA_HOME%"
-echo Using MOQUETTE_HOME:   "%MOQUETTE_HOME%"
+echo Using PULSAR_MQTT_PATH:   "%PULSAR_MQTT_PATH%"
 
-rem  set LOG_CONSOLE_LEVEL=info
-rem  set LOG_FILE_LEVEL=fine
+rem # This class has the main method to start the app
+set MAIN_CLASS=com.echostreams.pulsar.mqtt.broker.Server
+
 set JAVA_OPTS=
 set JAVA_OPTS_SCRIPT=-XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true
-set MOQUETTE_PATH=%MOQUETTE_HOME%
-set LOG_FILE=%MOQUETTE_HOME%\config\moquette-log.properties
+set PULSAR_MQTT_PATH=%PULSAR_MQTT_PATH%
 
 rem # Use the Hotspot garbage-first collector.
 set JAVA_OPTS=%JAVA_OPTS%  -XX:+UseG1GC
@@ -80,9 +79,9 @@ set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintTenuringDistribution
 set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintGCApplicationStoppedTime
 set JAVA_OPTS=%JAVA_OPTS% -XX:+PrintPromotionFailure
 rem set JAVA_OPTS=%JAVA_OPTS% -XX:PrintFLSStatistics=1
-rem set JAVA_OPTS=%JAVA_OPTS% -Xloggc:/var/log/moquette/gc.log
+set JAVA_OPTS=%JAVA_OPTS% -Xloggc:%PULSAR_MQTT_PATH%\logs\gc.log
 set JAVA_OPTS=%JAVA_OPTS% -XX:+UseGCLogFileRotation
 set JAVA_OPTS=%JAVA_OPTS% -XX:NumberOfGCLogFiles=10
 set JAVA_OPTS=%JAVA_OPTS% -XX:GCLogFileSize=10M
 
-%JAVA% -server %JAVA_OPTS% %JAVA_OPTS_SCRIPT% -Dmoquette.path=%MOQUETTE_PATH% -cp %MOQUETTE_HOME%\lib\* Server
+%JAVA% -server %JAVA_OPTS% %JAVA_OPTS_SCRIPT% -cp %PULSAR_MQTT_PATH%\lib\* %MAIN_CLASS%

--- a/src/main/resources/startApp.bat
+++ b/src/main/resources/startApp.bat
@@ -36,6 +36,13 @@ if exist { "%JAVA_HOME%\bin\java" } (
 echo Using JAVA_HOME:       "%JAVA_HOME%"
 echo Using PULSAR_MQTT_PATH:   "%PULSAR_MQTT_PATH%"
 
+rem create gc.log file
+IF NOT EXIST "%PULSAR_MQTT_PATH%\logs\gc.log" (
+    mkdir "%PULSAR_MQTT_PATH%\logs" 2>nul
+    type NUL > "%PULSAR_MQTT_PATH%\logs\gc.log"
+
+ )
+
 rem # This class has the main method to start the app
 set MAIN_CLASS=com.echostreams.pulsar.mqtt.broker.Server
 

--- a/src/main/resources/startApp.sh
+++ b/src/main/resources/startApp.sh
@@ -1,42 +1,17 @@
 #!/bin/sh
+# Copyright (c) 2019 Quinovas
 #
-# Copyright (c) 2012-2015 Andrea Selva
-#
 
-echo "                                                                         "
-echo "  ___  ___                       _   _        ___  ________ _____ _____  "
-echo "  |  \/  |                      | | | |       |  \/  |  _  |_   _|_   _| "
-echo "  | .  . | ___   __ _ _   _  ___| |_| |_ ___  | .  . | | | | | |   | |   "
-echo "  | |\/| |/ _ \ / _\ | | | |/ _ \ __| __/ _ \ | |\/| | | | | | |   | |   "
-echo "  | |  | | (_) | (_| | |_| |  __/ |_| ||  __/ | |  | \ \/' / | |   | |   "
-echo "  \_|  |_/\___/ \__, |\__,_|\___|\__|\__\___| \_|  |_/\_/\_\ \_/   \_/   "
-echo "                   | |                                                   "
-echo "                   |_|                                                   "
-echo "                                                                         "
-echo "                                               version: 0..13-SNAPSHOT   "
-
-
-cd "$(dirname "$0")"
-
-# resolve links - $0 may be a softlink
-PRG="$0"
-
-while [ -h "$PRG" ]; do
-  ls=`ls -ld "$PRG"`
-  link=`expr "$ls" : '.*-> \(.*\)$'`
-  if expr "$link" : '/.*' > /dev/null; then
-    PRG="$link"
-  else
-    PRG=`dirname "$PRG"`/"$link"
-  fi
-done
-
-# Get standard environment variables
-PRGDIR=`dirname "$PRG"`
-
-# Only set MOQUETTE_HOME if not already set
-[ -f "$MOQUETTE_HOME"/bin/moquette.sh ] || MOQUETTE_HOME=`cd "$PRGDIR/.." ; pwd`
-export MOQUETTE_HOME
+echo "                                                                          "
+echo "  ______      _                 ___  ________ _____ _____                 "
+echo "  | ___ \    | |                |  \/  |  _  |_   _|_   _|                "
+echo "  | |_/ /   _| |___  __ _ _ __  | .  . | | | | | |   | |                  "
+echo "  |  __/ | | | / __|/ _  | '__| | |\/| | | | | | |   | |                  "
+echo "  | |  | |_| | \__ \ (_| | |    | |  | \ \/' / | |   | |                  "
+echo "  \_|   \__,_|_|___/\__,_|_|    \_|  |_/\_/\_\ \_/   \_/                  "
+echo "										                                    "
+echo "                                 version: 1.0-SNAPSHOT   			        "
+echo "										                                    "
 
 # Set JavaHome if it exists
 if [ -f "${JAVA_HOME}/bin/java" ]; then 
@@ -46,10 +21,14 @@ else
 fi
 export JAVA
 
-LOG_FILE=$MOQUETTE_HOME/config/moquette-log.properties
-MOQUETTE_PATH=$MOQUETTE_HOME/
-#LOG_CONSOLE_LEVEL=info
-#LOG_FILE_LEVEL=fine
+PULSAR_MQTT_PATH=${PWD}
+
+echo Using JAVA_HOME:       "$JAVA_HOME"
+echo Using PULSAR_MQTT_PATH:   "$PULSAR_MQTT_PATH"
+
+## This class has the main method to start the app
+MAIN_CLASS=com.echostreams.pulsar.mqtt.broker.Server
+
 JAVA_OPTS_SCRIPT="-XX:+HeapDumpOnOutOfMemoryError -Djava.awt.headless=true"
 
 ## Use the Hotspot garbage-first collector.
@@ -88,10 +67,9 @@ JAVA_OPTS="$JAVA_OPTS -XX:+PrintTenuringDistribution"
 JAVA_OPTS="$JAVA_OPTS -XX:+PrintGCApplicationStoppedTime"
 JAVA_OPTS="$JAVA_OPTS -XX:+PrintPromotionFailure"
 #JAVA_OPTS="$JAVA_OPTS -XX:PrintFLSStatistics=1"
-#JAVA_OPTS="$JAVA_OPTS -Xloggc:/var/log/moquette/gc.log"
-JAVA_OPTS="$JAVA_OPTS -Xloggc:$MOQUETTE_HOME/gc.log"
+JAVA_OPTS="$JAVA_OPTS -Xloggc:$PULSAR_MQTT_PATH/logs/gc.log"
 JAVA_OPTS="$JAVA_OPTS -XX:+UseGCLogFileRotation"
 JAVA_OPTS="$JAVA_OPTS -XX:NumberOfGCLogFiles=10"
 JAVA_OPTS="$JAVA_OPTS -XX:GCLogFileSize=10M"
 
-$JAVA -server $JAVA_OPTS $JAVA_OPTS_SCRIPT -Dlog4j.configuration="file:$LOG_FILE" -Dmoquette.path="$MOQUETTE_PATH" -cp "$MOQUETTE_HOME/lib/*" Server
+$JAVA -server $JAVA_OPTS $JAVA_OPTS_SCRIPT -cp "$PULSAR_MQTT_PATH/lib/*" $MAIN_CLASS

--- a/src/main/resources/startApp.sh
+++ b/src/main/resources/startApp.sh
@@ -26,6 +26,12 @@ PULSAR_MQTT_PATH=${PWD}
 echo Using JAVA_HOME:       "$JAVA_HOME"
 echo Using PULSAR_MQTT_PATH:   "$PULSAR_MQTT_PATH"
 
+# create gc.log file
+if [! -f "$PULSAR_MQTT_PATH/logs/gc.log" ]; then
+   mkdir -p "$PULSAR_MQTT_PATH/logs"
+   touch "$PULSAR_MQTT_PATH/logs/gc.log"
+fi
+
 ## This class has the main method to start the app
 MAIN_CLASS=com.echostreams.pulsar.mqtt.broker.Server
 

--- a/src/test/java/com/echostreams/pulsar/mqtt/Utils.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/Utils.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.CorruptedFrameException;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+
+public final class Utils {
+
+    public static final int MAX_LENGTH_LIMIT = 268435455;
+
+    public static final byte VERSION_3_1 = 3;
+    public static final byte VERSION_3_1_1 = 4;
+
+    static byte readMessageType(ByteBuf in) {
+        byte h1 = in.readByte();
+        byte messageType = (byte) ((h1 & 0x00F0) >> 4);
+        return messageType;
+    }
+
+    static boolean checkHeaderAvailability(ByteBuf in) {
+        if (in.readableBytes() < 1) {
+            return false;
+        }
+        // byte h1 = in.get();
+        // byte messageType = (byte) ((h1 & 0x00F0) >> 4);
+        in.skipBytes(1); // skip the messageType byte
+
+        int remainingLength = Utils.decodeRemainingLenght(in);
+        if (remainingLength == -1) {
+            return false;
+        }
+
+        // check remaining length
+        if (in.readableBytes() < remainingLength) {
+            return false;
+        }
+
+        // return messageType == type ? MessageDecoderResult.OK : MessageDecoderResult.NOT_OK;
+        return true;
+    }
+
+    /**
+     * Decode the variable remaining length as defined in MQTT v3.1 specification (section 2.1).
+     *
+     * @return the decoded length or -1 if needed more data to decode the length field.
+     */
+    static int decodeRemainingLenght(ByteBuf in) {
+        int multiplier = 1;
+        int value = 0;
+        byte digit;
+        do {
+            if (in.readableBytes() < 1) {
+                return -1;
+            }
+            digit = in.readByte();
+            value += (digit & 0x7F) * multiplier;
+            multiplier *= 128;
+        } while ((digit & 0x80) != 0);
+        return value;
+    }
+
+    /**
+     * Encode the value in the format defined in specification as variable length array.
+     *
+     * @throws IllegalArgumentException
+     *             if the value is not in the specification bounds [0..268435455].
+     */
+    static ByteBuf encodeRemainingLength(int value) throws CorruptedFrameException {
+        if (value > MAX_LENGTH_LIMIT || value < 0) {
+            throw new CorruptedFrameException("Value should in range 0.." + MAX_LENGTH_LIMIT + " found " + value);
+        }
+
+        ByteBuf encoded = Unpooled.buffer(4);
+        byte digit;
+        do {
+            digit = (byte) (value % 128);
+            value = value / 128;
+            // if there are more digits to encode, set the top bit of this digit
+            if (value > 0) {
+                digit = (byte) (digit | 0x80);
+            }
+            encoded.writeByte(digit);
+        } while (value > 0);
+        return encoded;
+    }
+
+    /**
+     * Load a string from the given buffer, reading first the two bytes of len and then the UTF-8
+     * bytes of the string.
+     *
+     * @return the decoded string or null if NEED_DATA
+     */
+    static String decodeString(ByteBuf in) throws UnsupportedEncodingException {
+        return new String(readFixedLengthContent(in), "UTF-8");
+    }
+
+    /**
+     * Read a byte array from the buffer, use two bytes as length information followed by length
+     * bytes.
+     */
+    static byte[] readFixedLengthContent(ByteBuf in) throws UnsupportedEncodingException {
+        if (in.readableBytes() < 2) {
+            return null;
+        }
+        int strLen = in.readUnsignedShort();
+        if (in.readableBytes() < strLen) {
+            return null;
+        }
+        byte[] strRaw = new byte[strLen];
+        in.readBytes(strRaw);
+
+        return strRaw;
+    }
+
+    /**
+     * Return the IoBuffer with string encoded as MSB, LSB and UTF-8 encoded string content.
+     */
+    public static ByteBuf encodeString(String str) {
+        byte[] raw;
+        try {
+            raw = str.getBytes("UTF-8");
+            // NB every Java platform has got UTF-8 encoding by default, so this
+            // exception are never raised.
+        } catch (UnsupportedEncodingException ex) {
+            LoggerFactory.getLogger(Utils.class).error(null, ex);
+            return null;
+        }
+        return encodeFixedLengthContent(raw);
+    }
+
+    /**
+     * Return the IoBuffer with string encoded as MSB, LSB and bytes array content.
+     */
+    public static ByteBuf encodeFixedLengthContent(byte[] content) {
+        ByteBuf out = Unpooled.buffer(2);
+        out.writeShort(content.length);
+        out.writeBytes(content);
+        return out;
+    }
+
+    /**
+     * Return the number of bytes to encode the given remaining length value
+     */
+    static int numBytesToEncode(int len) {
+        if (0 <= len && len <= 127)
+            return 1;
+        if (128 <= len && len <= 16383)
+            return 2;
+        if (16384 <= len && len <= 2097151)
+            return 3;
+        if (2097152 <= len && len <= 268435455)
+            return 4;
+        throw new IllegalArgumentException("value should be in the range [0..268435455]");
+    }
+
+    static byte encodeFlags(MqttMessage message) {
+        byte flags = 0;
+        if (message.fixedHeader().isDup()) {
+            flags |= (byte) 0x08;
+        }
+        if (message.fixedHeader().isRetain()) {
+            flags |= (byte) 0x01;
+        }
+
+        flags |= (byte) ((message.fixedHeader().qosLevel().value() & 0x03) << 1);
+        return flags;
+    }
+
+    // 3 = 3.1, 4 = 3.1.1
+    // static final AttributeKey<Integer> PROTOCOL_VERSION = AttributeKey.valueOf("version");
+    //
+    // static boolean isMQTT3_1_1(AttributeMap attrsMap) {
+    // Attribute<Integer> versionAttr = attrsMap.attr(PROTOCOL_VERSION);
+    // Integer protocolVersion = versionAttr.get();
+    // if (protocolVersion == null) {
+    // return true;
+    // }
+    // return protocolVersion == VERSION_3_1_1;
+    // }
+
+    private Utils() {
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/BrokerConfigurationTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/BrokerConfigurationTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.config.MemoryConfig;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BrokerConfigurationTest {
+
+    @Test
+    public void defaultConfig() {
+        MemoryConfig config = new MemoryConfig(new Properties());
+        BrokerConfiguration brokerConfiguration = new BrokerConfiguration(config);
+        assertTrue(brokerConfiguration.isAllowAnonymous());
+        assertFalse(brokerConfiguration.isAllowZeroByteClientId());
+        assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
+        assertFalse(brokerConfiguration.isImmediateBufferFlush());
+    }
+
+    @Test
+    public void configureAllowAnonymous() {
+        Properties properties = new Properties();
+        properties.put(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, "false");
+        MemoryConfig config = new MemoryConfig(properties);
+        BrokerConfiguration brokerConfiguration = new BrokerConfiguration(config);
+        assertFalse(brokerConfiguration.isAllowAnonymous());
+        assertFalse(brokerConfiguration.isAllowZeroByteClientId());
+        assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
+        assertFalse(brokerConfiguration.isImmediateBufferFlush());
+    }
+
+    @Test
+    public void configureAllowZeroByteClientId() {
+        Properties properties = new Properties();
+        properties.put(BrokerConstants.ALLOW_ZERO_BYTE_CLIENT_ID_PROPERTY_NAME, "true");
+        MemoryConfig config = new MemoryConfig(properties);
+        BrokerConfiguration brokerConfiguration = new BrokerConfiguration(config);
+        assertTrue(brokerConfiguration.isAllowAnonymous());
+        assertTrue(brokerConfiguration.isAllowZeroByteClientId());
+        assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
+        assertFalse(brokerConfiguration.isImmediateBufferFlush());
+    }
+
+    @Test
+    public void configureReauthorizeSubscriptionsOnConnect() {
+        Properties properties = new Properties();
+        properties.put(BrokerConstants.REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT, "true");
+        MemoryConfig config = new MemoryConfig(properties);
+        BrokerConfiguration brokerConfiguration = new BrokerConfiguration(config);
+        assertTrue(brokerConfiguration.isAllowAnonymous());
+        assertFalse(brokerConfiguration.isAllowZeroByteClientId());
+        assertTrue(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
+        assertFalse(brokerConfiguration.isImmediateBufferFlush());
+    }
+
+    @Test
+    public void configureImmediateBufferFlush() {
+        Properties properties = new Properties();
+        properties.put(BrokerConstants.IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME, "true");
+        MemoryConfig config = new MemoryConfig(properties);
+        BrokerConfiguration brokerConfiguration = new BrokerConfiguration(config);
+        assertTrue(brokerConfiguration.isAllowAnonymous());
+        assertFalse(brokerConfiguration.isAllowZeroByteClientId());
+        assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
+        assertTrue(brokerConfiguration.isImmediateBufferFlush());
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/ConnectionTestUtils.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/ConnectionTestUtils.java
@@ -16,6 +16,7 @@
 
 package com.echostreams.pulsar.mqtt.broker;
 
+import com.echostreams.pulsar.mqtt.broker.utils.DebugUtils;
 import com.echostreams.pulsar.mqtt.interception.BrokerInterceptor;
 import com.echostreams.pulsar.mqtt.interception.InterceptHandler;
 import io.netty.channel.embedded.EmbeddedChannel;

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/ConnectionTestUtils.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/ConnectionTestUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.interception.BrokerInterceptor;
+import com.echostreams.pulsar.mqtt.interception.InterceptHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
+import static org.junit.Assert.*;
+
+public final class ConnectionTestUtils {
+
+    public static final List<InterceptHandler> EMPTY_OBSERVERS = Collections.emptyList();
+    public static final BrokerInterceptor NO_OBSERVERS_INTERCEPTOR = new BrokerInterceptor(EMPTY_OBSERVERS);
+
+    private ConnectionTestUtils() {
+    }
+
+    static void assertConnectAccepted(EmbeddedChannel channel) {
+        MqttConnAckMessage connAck = channel.readOutbound();
+        final MqttConnectReturnCode connAckReturnCode = connAck.variableHeader().connectReturnCode();
+        assertEquals("Connect must be accepted", CONNECTION_ACCEPTED, connAckReturnCode);
+    }
+
+    static void verifyReceivePublish(EmbeddedChannel embeddedChannel, String expectedTopic, String expectedContent) {
+        MqttPublishMessage receivedPublish = embeddedChannel.flushOutbound().readOutbound();
+        assertPublishIsCorrect(expectedTopic, expectedContent, receivedPublish);
+    }
+
+    private static void assertPublishIsCorrect(String expectedTopic, String expectedContent,
+                                               MqttPublishMessage receivedPublish) {
+        assertNotNull("Expecting a PUBLISH message", receivedPublish);
+        final String decodedPayload = DebugUtils.payload2Str(receivedPublish.payload());
+        assertEquals(expectedContent, decodedPayload);
+        assertEquals(expectedTopic, receivedPublish.variableHeader().topicName());
+    }
+
+    static void verifyReceiveRetainedPublish(EmbeddedChannel embeddedChannel, String expectedTopic,
+                                             String expectedContent) {
+        MqttPublishMessage receivedPublish = embeddedChannel.readOutbound();
+        assertPublishIsCorrect(expectedTopic, expectedContent, receivedPublish);
+        assertTrue("MUST be retained publish", receivedPublish.fixedHeader().isRetain());
+    }
+
+    static void verifyReceiveRetainedPublish(EmbeddedChannel embeddedChannel, String expectedTopic,
+                                             String expectedContent, MqttQoS expectedQos) {
+        MqttPublishMessage receivedPublish = embeddedChannel.flushOutbound().readOutbound();
+        assertEquals(receivedPublish.fixedHeader().qosLevel(), expectedQos);
+        assertPublishIsCorrect(expectedTopic, expectedContent, receivedPublish);
+        assertTrue("MUST be retained publish", receivedPublish.fixedHeader().isRetain());
+    }
+
+    static void verifyPublishIsReceived(EmbeddedChannel embCh, MqttQoS expectedQos, String expectedPayload) {
+        final MqttPublishMessage publishReceived = embCh.flushOutbound().readOutbound();
+        final String payloadMessage = DebugUtils.payload2Str(publishReceived.payload());
+        assertEquals("Sent and received payload must be identical", expectedPayload, payloadMessage);
+        assertEquals("Expected QoS don't match", expectedQos, publishReceived.fixedHeader().qosLevel());
+    }
+
+    static void verifyNoPublishIsReceived(EmbeddedChannel channel) {
+        final Object messageReceived = channel.readOutbound();
+        assertNull("Received an out message from processor while not expected", messageReceived);
+    }
+
+    static MqttConnectMessage buildConnect(String clientId) {
+        return MqttMessageBuilders.connect()
+            .clientId(clientId)
+            .build();
+    }
+
+    static MqttConnectMessage buildConnectNotClean(String clientId) {
+        return MqttMessageBuilders.connect()
+            .clientId(clientId)
+            .cleanSession(false)
+            .build();
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/MQTTConnectionConnectTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/MQTTConnectionConnectTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.security.IAuthenticator;
+import com.echostreams.pulsar.mqtt.broker.security.PermitAllAuthorizatorPolicy;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.CTrieSubscriptionDirectory;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.ISubscriptionsDirectory;
+import com.echostreams.pulsar.mqtt.persistence.MemorySubscriptionsRepository;
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttVersion;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.*;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class MQTTConnectionConnectTest {
+
+    private static final String FAKE_CLIENT_ID = "FAKE_123";
+    private static final String TEST_USER = "fakeuser";
+    private static final String TEST_PWD = "fakepwd";
+    private static final String EVIL_TEST_USER = "eviluser";
+    private static final String EVIL_TEST_PWD = "unsecret";
+
+    private MQTTConnection sut;
+    private EmbeddedChannel channel;
+    private SessionRegistry sessionRegistry;
+    private MqttMessageBuilders.ConnectBuilder connMsg;
+    private static final BrokerConfiguration CONFIG = new BrokerConfiguration(true, true, false, false);
+    private IAuthenticator mockAuthenticator;
+    private PostOffice postOffice;
+    private MemoryQueueRepository queueRepository;
+
+    @Before
+    public void setUp() {
+        connMsg = MqttMessageBuilders.connect().protocolVersion(MqttVersion.MQTT_3_1).cleanSession(true);
+
+        mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID), singletonMap(TEST_USER, TEST_PWD));
+
+        ISubscriptionsDirectory subscriptions = new CTrieSubscriptionDirectory();
+        ISubscriptionsRepository subscriptionsRepository = new MemorySubscriptionsRepository();
+        subscriptions.init(subscriptionsRepository);
+        queueRepository = new MemoryQueueRepository();
+
+        final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
+        final Authorizator permitAll = new Authorizator(authorizatorPolicy);
+        sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        postOffice = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
+                                    ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+
+        sut = createMQTTConnection(CONFIG);
+        channel = (EmbeddedChannel) sut.channel;
+    }
+
+    private MQTTConnection createMQTTConnection(BrokerConfiguration config) {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        return createMQTTConnection(config, channel, postOffice);
+    }
+
+    private MQTTConnection createMQTTConnectionWithPostOffice(BrokerConfiguration config, PostOffice postOffice) {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        return createMQTTConnection(config, channel, postOffice);
+    }
+
+    private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel, PostOffice postOffice) {
+        return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);
+    }
+
+    @Test
+    public void testZeroByteClientIdWithCleanSession() {
+        // Connect message with clean session set to true and client id is null.
+        MqttConnectMessage msg = MqttMessageBuilders.connect()
+            .protocolVersion(MqttVersion.MQTT_3_1_1)
+            .clientId(null)
+            .cleanSession(true)
+            .build();
+
+        sut.processConnect(msg);
+        NettyChannelAssertions.assertEqualsConnAck("Connection must be accepted", CONNECTION_ACCEPTED, channel.readOutbound());
+        assertNotNull("unique clientid must be generated", sut.getClientId());
+        assertTrue("clean session flag must be true", sessionRegistry.retrieve(sut.getClientId()).isClean());
+        assertTrue("Connection must be open", channel.isOpen());
+    }
+
+    @Test
+    public void invalidAuthentication() {
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID)
+            .username(TEST_USER + "_fake")
+            .password(TEST_PWD)
+            .build();
+
+        // Exercise
+        sut.processConnect(msg);
+
+        // Verify
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD, channel.readOutbound());
+        assertFalse("Connection should be closed by the broker.", channel.isOpen());
+    }
+
+    @Test
+    public void testConnect_badClientID() {
+        connMsg.clientId("extremely_long_clientID_greater_than_23").build();
+
+        // Exercise
+        sut.processConnect(connMsg.clientId("extremely_long_clientID_greater_than_23").build());
+
+        // Verify
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
+    }
+
+    @Test
+    public void testWillIsAccepted() {
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).willFlag(true)
+            .willTopic("topic").willMessage("Topic message").build();
+
+        // Exercise
+        // m_handler.setMessaging(mockedMessaging);
+        sut.processConnect(msg);
+
+        // Verify
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
+        assertTrue("Connection is accepted and therefore should remain open", channel.isOpen());
+    }
+
+    @Test
+    public void testWillIsFired() {
+        final PostOffice postOfficeMock = mock(PostOffice.class);
+        sut = createMQTTConnectionWithPostOffice(CONFIG, postOfficeMock);
+        channel = (EmbeddedChannel) sut.channel;
+
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).willFlag(true)
+            .willTopic("topic").willMessage("Topic message").build();
+        sut.processConnect(msg);
+
+        // Exercise
+        sut.handleConnectionLost();
+
+        // Verify
+        verify(postOfficeMock).fireWill(any(Session.Will.class));
+        assertFalse("Connection MUST be disconnected", sut.isConnected());
+    }
+
+    @Test
+    public void acceptAnonymousClient() {
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).build();
+
+        // Exercise
+        sut.processConnect(msg);
+
+        // Verify
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
+        assertTrue("Connection is accepted and therefore must remain open", channel.isOpen());
+    }
+
+    @Test
+    public void validAuthentication() {
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID)
+            .username(TEST_USER).password(TEST_PWD).build();
+
+        // Exercise
+        sut.processConnect(msg);
+
+        // Verify
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
+        assertTrue("Connection is accepted and therefore must remain open", channel.isOpen());
+    }
+
+    @Test
+    public void noPasswdAuthentication() {
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID)
+            .username(TEST_USER)
+            .build();
+
+        // Exercise
+        sut.processConnect(msg);
+
+        // Verify
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD, channel.readOutbound());
+        assertFalse("Connection must be closed by the broker", channel.isOpen());
+    }
+
+    @Test
+    public void prohibitAnonymousClient() {
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).build();
+        BrokerConfiguration config = new BrokerConfiguration(false, true, false, false);
+
+        sut = createMQTTConnection(config);
+        channel = (EmbeddedChannel) sut.channel;
+
+        // Exercise
+        sut.processConnect(msg);
+
+        // Verify
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD, channel.readOutbound());
+        assertFalse("Connection must be closed by the broker", channel.isOpen());
+    }
+
+    @Test
+    public void prohibitAnonymousClient_providingUsername() {
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID)
+            .username(TEST_USER + "_fake")
+            .build();
+        BrokerConfiguration config = new BrokerConfiguration(false, true, false, false);
+
+        createMQTTConnection(config);
+
+        // Exercise
+        sut.processConnect(msg);
+
+        // Verify
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD, channel.readOutbound());
+        assertFalse("Connection should be closed by the broker.", channel.isOpen());
+    }
+
+    @Test
+    public void testZeroByteClientIdNotAllowed() {
+        BrokerConfiguration config = new BrokerConfiguration(false, false, false, false);
+
+        sut = createMQTTConnection(config);
+        channel = (EmbeddedChannel) sut.channel;
+
+        // Connect message with clean session set to true and client id is null.
+        MqttConnectMessage msg = connMsg.clientId(null)
+            .protocolVersion(MqttVersion.MQTT_3_1_1)
+            .cleanSession(true)
+            .build();
+
+        sut.processConnect(msg);
+        NettyChannelAssertions.assertEqualsConnAck("Zero byte client identifiers are not allowed",
+                CONNECTION_REFUSED_IDENTIFIER_REJECTED, channel.readOutbound());
+        assertFalse("Connection must closed", channel.isOpen());
+    }
+
+    @Test
+    public void testZeroByteClientIdWithoutCleanSession() {
+        // Allow zero byte client ids
+        // Connect message without clean session set to true but client id is still null
+        MqttConnectMessage msg = MqttMessageBuilders.connect().clientId(null).protocolVersion(MqttVersion.MQTT_3_1_1)
+            .build();
+
+        sut.processConnect(msg);
+        NettyChannelAssertions.assertEqualsConnAck("Identifier must be rejected due to having clean session set to false",
+                CONNECTION_REFUSED_IDENTIFIER_REJECTED, channel.readOutbound());
+        assertFalse("Connection must be closed by the broker", channel.isOpen());
+    }
+
+    @Test
+    public void testBindWithSameClientIDBadCredentialsDoesntDropExistingClient() {
+        // Connect a client1
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID)
+            .username(TEST_USER)
+            .password(TEST_PWD)
+            .build();
+        sut.processConnect(msg);
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
+
+        // create another connect same clientID but with bad credentials
+        MqttConnectMessage evilClientConnMsg = MqttMessageBuilders.connect()
+            .protocolVersion(MqttVersion.MQTT_3_1)
+            .clientId(FAKE_CLIENT_ID)
+            .username(EVIL_TEST_USER)
+            .password(EVIL_TEST_PWD)
+            .build();
+
+        EmbeddedChannel evilChannel = new EmbeddedChannel();
+
+        // Exercise
+        BrokerConfiguration config = new BrokerConfiguration(true, true, false, false);
+        final MQTTConnection evilConnection = createMQTTConnection(config, evilChannel, postOffice);
+        evilConnection.processConnect(evilClientConnMsg);
+
+        // Verify
+        // the evil client gets a not auth notification
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD, evilChannel.readOutbound());
+        // the good client remains connected
+        assertTrue("Original connected client must remain connected", channel.isOpen());
+        assertFalse("Channel trying to connect with bad credentials must be closed", evilChannel.isOpen());
+    }
+
+    @Test
+    public void testForceClientDisconnection_issue116() {
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID)
+            .username(TEST_USER)
+            .password(TEST_PWD)
+            .build();
+        sut.processConnect(msg);
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
+
+        // now create another connection and check the new one closes the older
+        MQTTConnection anotherConnection = createMQTTConnection(CONFIG);
+        anotherConnection.processConnect(msg);
+        EmbeddedChannel anotherChannel = (EmbeddedChannel) anotherConnection.channel;
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_ACCEPTED, anotherChannel.readOutbound());
+
+        // Verify
+        assertFalse("First 'FAKE_CLIENT_ID' channel MUST be closed by the broker", channel.isOpen());
+        assertTrue("Second 'FAKE_CLIENT_ID' channel MUST be still open", anotherChannel.isOpen());
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/MQTTConnectionPublishTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/MQTTConnectionPublishTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.security.IAuthenticator;
+import com.echostreams.pulsar.mqtt.broker.security.PermitAllAuthorizatorPolicy;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.CTrieSubscriptionDirectory;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.ISubscriptionsDirectory;
+import com.echostreams.pulsar.mqtt.persistence.MemorySubscriptionsRepository;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttVersion;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertFalse;
+
+public class MQTTConnectionPublishTest {
+
+    private static final String FAKE_CLIENT_ID = "FAKE_123";
+    private static final String TEST_USER = "fakeuser";
+    private static final String TEST_PWD = "fakepwd";
+
+    private MQTTConnection sut;
+    private EmbeddedChannel channel;
+    private SessionRegistry sessionRegistry;
+    private MqttMessageBuilders.ConnectBuilder connMsg;
+    private MemoryQueueRepository queueRepository;
+
+    @Before
+    public void setUp() {
+        connMsg = MqttMessageBuilders.connect().protocolVersion(MqttVersion.MQTT_3_1).cleanSession(true);
+
+        BrokerConfiguration config = new BrokerConfiguration(true, true, false, false);
+
+        createMQTTConnection(config);
+    }
+
+    private void createMQTTConnection(BrokerConfiguration config) {
+        channel = new EmbeddedChannel();
+        sut = createMQTTConnection(config, channel);
+    }
+
+    private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
+        IAuthenticator mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID),
+                                                                 singletonMap(TEST_USER, TEST_PWD));
+
+        ISubscriptionsDirectory subscriptions = new CTrieSubscriptionDirectory();
+        ISubscriptionsRepository subscriptionsRepository = new MemorySubscriptionsRepository();
+        subscriptions.init(subscriptionsRepository);
+        queueRepository = new MemoryQueueRepository();
+
+        final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
+        final Authorizator permitAll = new Authorizator(authorizatorPolicy);
+        sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        final PostOffice postOffice = new PostOffice(subscriptions,
+            new MemoryRetainedRepository(), sessionRegistry, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+        return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);
+    }
+
+    @Test
+    public void dropConnectionOnPublishWithInvalidTopicFormat() {
+        // Connect message with clean session set to true and client id is null.
+        MqttPublishMessage publish = MqttMessageBuilders.publish()
+            .topicName("")
+            .retained(false)
+            .qos(MqttQoS.AT_MOST_ONCE)
+            .payload(Unpooled.copiedBuffer("Hello MQTT world!".getBytes(UTF_8))).build();
+
+        sut.processPublish(publish);
+
+        // Verify
+        assertFalse("Connection should be closed by the broker", channel.isOpen());
+    }
+
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/MockAuthenticator.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/MockAuthenticator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.security.IAuthenticator;
+
+import java.util.Map;
+import java.util.Set;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Test utility to implements authenticator instance.
+ */
+public class MockAuthenticator implements IAuthenticator {
+
+    private Set<String> m_clientIds;
+    private Map<String, String> m_userPwds;
+
+    public MockAuthenticator(Set<String> clientIds, Map<String, String> userPwds) {
+        m_clientIds = clientIds;
+        m_userPwds = userPwds;
+    }
+
+    @Override
+    public boolean checkValid(String clientId, String username, byte[] password) {
+        if (!m_clientIds.contains(clientId)) {
+            return false;
+        }
+        if (!m_userPwds.containsKey(username)) {
+            return false;
+        }
+        if (password == null) {
+            return false;
+        }
+        return m_userPwds.get(username).equals(new String(password, UTF_8));
+    }
+
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/NettyChannelAssertions.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/NettyChannelAssertions.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.MqttConnAckMessage;
+import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
+import io.netty.handler.codec.mqtt.MqttSubAckMessage;
+
+import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Some useful assertions used by Netty's EmbeddedChannel in tests.
+ */
+public final class NettyChannelAssertions {
+
+    public static void assertEqualsConnAck(MqttConnectReturnCode expectedCode, Object connAck) {
+        assertEqualsConnAck(null, expectedCode, connAck);
+    }
+
+    public static void assertEqualsConnAck(String msg, MqttConnectReturnCode expectedCode, Object connAck) {
+        assertTrue("connAck is not an instance of ConnAckMessage", connAck instanceof MqttConnAckMessage);
+        MqttConnAckMessage connAckMsg = (MqttConnAckMessage) connAck;
+
+        if (msg == null)
+            assertEquals(expectedCode, connAckMsg.variableHeader().connectReturnCode());
+        else
+            assertEquals(msg, expectedCode, connAckMsg.variableHeader().connectReturnCode());
+    }
+
+    public static void assertConnAckAccepted(EmbeddedChannel channel) {
+        channel.flush();
+        assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
+    }
+
+    public static void assertEqualsSubAck(/* byte expectedCode, */ Object subAck) {
+        assertTrue(subAck instanceof MqttSubAckMessage);
+        // SubAckMessage connAckMsg = (SubAckMessage) connAck;
+        // assertEquals(expectedCode, connAckMsg.getReturnCode());
+    }
+
+    private NettyChannelAssertions() {
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/PostOfficeInternalPublishTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/PostOfficeInternalPublishTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.security.PermitAllAuthorizatorPolicy;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.CTrieSubscriptionDirectory;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.ISubscriptionsDirectory;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import com.echostreams.pulsar.mqtt.persistence.MemorySubscriptionsRepository;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static com.echostreams.pulsar.mqtt.broker.PostOfficeUnsubscribeTest.CONFIG;
+import static io.netty.handler.codec.mqtt.MqttQoS.*;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class PostOfficeInternalPublishTest {
+
+    private static final String FAKE_CLIENT_ID = "FAKE_123";
+    private static final String TEST_USER = "fakeuser";
+    private static final String TEST_PWD = "fakepwd";
+    private static final String PAYLOAD = "Hello MQTT World";
+
+    private MQTTConnection connection;
+    private EmbeddedChannel channel;
+    private PostOffice sut;
+    private ISubscriptionsDirectory subscriptions;
+    private MqttConnectMessage connectMessage;
+    private SessionRegistry sessionRegistry;
+    private MockAuthenticator mockAuthenticator;
+    private static final BrokerConfiguration ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID =
+        new BrokerConfiguration(true, true, false, false);
+    private MemoryRetainedRepository retainedRepository;
+    private MemoryQueueRepository queueRepository;
+
+    @Before
+    public void setUp() {
+        sessionRegistry = initPostOfficeAndSubsystems();
+
+        mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID), singletonMap(TEST_USER, TEST_PWD));
+        connection = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID);
+
+        connectMessage = ConnectionTestUtils.buildConnect(FAKE_CLIENT_ID);
+
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+    }
+
+    private MQTTConnection createMQTTConnection(BrokerConfiguration config) {
+        channel = new EmbeddedChannel();
+        return createMQTTConnection(config, channel);
+    }
+
+    private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
+        return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, sut);
+    }
+
+    private SessionRegistry initPostOfficeAndSubsystems() {
+        subscriptions = new CTrieSubscriptionDirectory();
+        ISubscriptionsRepository subscriptionsRepository = new MemorySubscriptionsRepository();
+        subscriptions.init(subscriptionsRepository);
+        retainedRepository = new MemoryRetainedRepository();
+        queueRepository = new MemoryQueueRepository();
+
+        final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
+        final Authorizator permitAll = new Authorizator(authorizatorPolicy);
+        SessionRegistry sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+        return sessionRegistry;
+    }
+
+    private void internalPublishNotRetainedTo(String topic) {
+        internalPublishTo(topic, AT_MOST_ONCE, false);
+    }
+
+    private void internalPublishRetainedTo(String topic) {
+        internalPublishTo(topic, AT_MOST_ONCE, true);
+    }
+
+    private void internalPublishTo(String topic, MqttQoS qos, boolean retained) {
+        MqttPublishMessage publish = MqttMessageBuilders.publish()
+            .topicName(topic)
+            .retained(retained)
+            .qos(qos)
+            .payload(Unpooled.copiedBuffer(PAYLOAD.getBytes(UTF_8))).build();
+        sut.internalPublish(publish);
+    }
+
+    @Test
+    public void testClientSubscribeAfterNotRetainedQoS0IsSent() {
+//        connection.processConnect(connectMessage);
+//        ConnectionTestUtils.assertConnectAccepted(channel);
+
+        // Exercise
+        final String topic = "/topic";
+        internalPublishNotRetainedTo(topic);
+
+        subscribe(AT_MOST_ONCE, topic, connection);
+
+        // Verify
+        verifyNoPublishIsReceived(channel);
+    }
+
+    @Test
+    public void testClientSubscribeAfterRetainedQoS0IsSent() {
+        // Exercise
+        final String topic = "/topic";
+        internalPublishRetainedTo(topic);
+
+        subscribe(AT_MOST_ONCE, topic, connection);
+
+        // Verify
+        verifyNoPublishIsReceived(channel);
+    }
+
+    @Test
+    public void testClientSubscribeBeforeNotRetainedQoS0IsSent() {
+        subscribe(AT_MOST_ONCE, "/topic", connection);
+
+        // Exercise
+        internalPublishNotRetainedTo("/topic");
+
+        // Verify
+        ConnectionTestUtils.verifyPublishIsReceived(channel, AT_MOST_ONCE, PAYLOAD);
+    }
+
+    @Test
+    public void testClientSubscribeBeforeRetainedQoS0IsSent() {
+        subscribe(AT_MOST_ONCE, "/topic", connection);
+
+        // Exercise
+        internalPublishRetainedTo("/topic");
+
+        // Verify
+        ConnectionTestUtils.verifyPublishIsReceived(channel, AT_MOST_ONCE, PAYLOAD);
+    }
+
+    @Test
+    public void testClientSubscribeBeforeNotRetainedQoS1IsSent() {
+        subscribe(AT_LEAST_ONCE, "/topic", connection);
+
+        // Exercise
+        internalPublishTo("/topic", AT_LEAST_ONCE, false);
+
+        // Verify
+        ConnectionTestUtils.verifyPublishIsReceived(channel, AT_LEAST_ONCE, PAYLOAD);
+    }
+
+    @Test
+    public void testClientSubscribeAfterNotRetainedQoS1IsSent() {
+        // Exercise
+        internalPublishTo("/topic", AT_LEAST_ONCE, false);
+        subscribe(AT_LEAST_ONCE, "/topic", connection);
+
+        // Verify
+        verifyNoPublishIsReceived(channel);
+    }
+
+    @Test
+    public void testClientSubscribeBeforeRetainedQoS1IsSent() {
+        subscribe(AT_LEAST_ONCE, "/topic", connection);
+
+        // Exercise
+        internalPublishTo("/topic", AT_LEAST_ONCE, true);
+
+        // Verify
+        ConnectionTestUtils.verifyPublishIsReceived(channel, AT_LEAST_ONCE, PAYLOAD);
+    }
+
+    @Test
+    public void testClientSubscribeAfterRetainedQoS1IsSent() {
+        // Exercise
+        internalPublishTo("/topic", AT_LEAST_ONCE, true);
+        subscribe(AT_LEAST_ONCE, "/topic", connection);
+
+        // Verify
+        ConnectionTestUtils.verifyPublishIsReceived(channel, AT_LEAST_ONCE, PAYLOAD);
+    }
+
+    @Test
+    public void testClientSubscribeBeforeNotRetainedQoS2IsSent() {
+        subscribe(EXACTLY_ONCE, "/topic", connection);
+
+        // Exercise
+        internalPublishTo("/topic", EXACTLY_ONCE, false);
+
+        // Verify
+        ConnectionTestUtils.verifyPublishIsReceived(channel, EXACTLY_ONCE, PAYLOAD);
+    }
+
+    @Test
+    public void testClientSubscribeAfterNotRetainedQoS2IsSent() {
+        // Exercise
+        internalPublishTo("/topic", EXACTLY_ONCE, false);
+        subscribe(EXACTLY_ONCE, "/topic", connection);
+
+        // Verify
+        verifyNoPublishIsReceived(channel);
+    }
+
+    @Test
+    public void testClientSubscribeBeforeRetainedQoS2IsSent() {
+        subscribe(EXACTLY_ONCE, "/topic", connection);
+
+        // Exercise
+        internalPublishTo("/topic", EXACTLY_ONCE, true);
+
+        // Verify
+        ConnectionTestUtils.verifyPublishIsReceived(channel, EXACTLY_ONCE, PAYLOAD);
+    }
+
+    @Test
+    public void testClientSubscribeAfterRetainedQoS2IsSent() {
+        // Exercise
+        internalPublishTo("/topic", EXACTLY_ONCE, true);
+        subscribe(EXACTLY_ONCE, "/topic", connection);
+
+        // Verify
+        ConnectionTestUtils.verifyPublishIsReceived(channel, EXACTLY_ONCE, PAYLOAD);
+    }
+
+    @Test
+    public void testClientSubscribeAfterDisconnected() {
+        subscribe(AT_MOST_ONCE, "foo", connection);
+        connection.processDisconnect(null);
+
+        internalPublishTo("foo", AT_MOST_ONCE, false);
+
+        verifyNoPublishIsReceived(channel);
+    }
+
+    @Test
+    public void testClientSubscribeWithoutCleanSession() {
+        subscribe(AT_MOST_ONCE, "foo", connection);
+        connection.processDisconnect(null);
+        assertEquals(1, subscriptions.size());
+
+        MQTTConnection anotherConn = createMQTTConnection(CONFIG);
+
+        MqttConnectMessage connectMessage = MqttMessageBuilders.connect()
+            .clientId(FAKE_CLIENT_ID)
+            .cleanSession(false)
+            .build();
+        anotherConn.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted((EmbeddedChannel) anotherConn.channel);
+
+        assertEquals(1, subscriptions.size());
+        internalPublishTo("foo", MqttQoS.AT_MOST_ONCE, false);
+        ConnectionTestUtils.verifyPublishIsReceived((EmbeddedChannel) anotherConn.channel, AT_MOST_ONCE, PAYLOAD);
+    }
+
+    private void subscribe(MqttQoS topic, String newsTopic, MQTTConnection connection) {
+        MqttSubscribeMessage subscribe = MqttMessageBuilders.subscribe()
+            .addSubscription(topic, newsTopic)
+            .messageId(1)
+            .build();
+        sut.subscribeClientToTopics(subscribe, connection.getClientId(), null, this.connection);
+
+        MqttSubAckMessage subAck = ((EmbeddedChannel) this.connection.channel).readOutbound();
+        assertEquals(topic.value(), (int) subAck.payload().grantedQoSLevels().get(0));
+    }
+
+    protected void subscribe(MQTTConnection connection, String topic, MqttQoS desiredQos) {
+        EmbeddedChannel channel = (EmbeddedChannel) connection.channel;
+        MqttSubscribeMessage subscribe = MqttMessageBuilders.subscribe()
+            .addSubscription(desiredQos, topic)
+            .messageId(1)
+            .build();
+        sut.subscribeClientToTopics(subscribe, connection.getClientId(), null, connection);
+
+        MqttSubAckMessage subAck = channel.readOutbound();
+        assertEquals(desiredQos.value(), (int) subAck.payload().grantedQoSLevels().get(0));
+
+        final String clientId = connection.getClientId();
+        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
+
+        final Set<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
+        assertEquals(1, matchedSubscriptions.size());
+        final Subscription onlyMatchedSubscription = matchedSubscriptions.iterator().next();
+        assertEquals(expectedSubscription, onlyMatchedSubscription);
+    }
+
+    private void verifyNoPublishIsReceived(EmbeddedChannel channel) {
+        final Object messageReceived = channel.readOutbound();
+        assertNull("Received an out message from processor while not expected", messageReceived);
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/PostOfficePublishTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/PostOfficePublishTest.java
@@ -1,0 +1,418 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.security.PermitAllAuthorizatorPolicy;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.CTrieSubscriptionDirectory;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.ISubscriptionsDirectory;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import com.echostreams.pulsar.mqtt.persistence.MemorySubscriptionsRepository;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.echostreams.pulsar.mqtt.broker.PostOfficeUnsubscribeTest.CONFIG;
+import static io.netty.handler.codec.mqtt.MqttQoS.*;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.*;
+
+public class PostOfficePublishTest {
+
+    private static final String FAKE_CLIENT_ID = "FAKE_123";
+    private static final String FAKE_CLIENT_ID2 = "FAKE_456";
+    static final String SUBSCRIBER_ID = "Subscriber";
+    static final String PUBLISHER_ID = "Publisher";
+    private static final String TEST_USER = "fakeuser";
+    private static final String TEST_PWD = "fakepwd";
+    private static final String NEWS_TOPIC = "/news";
+    private static final String BAD_FORMATTED_TOPIC = "#MQTTClient";
+
+    private MQTTConnection connection;
+    private EmbeddedChannel channel;
+    private PostOffice sut;
+    private ISubscriptionsDirectory subscriptions;
+    public static final String FAKE_USER_NAME = "UnAuthUser";
+    private MqttConnectMessage connectMessage;
+    private SessionRegistry sessionRegistry;
+    private MockAuthenticator mockAuthenticator;
+    static final BrokerConfiguration ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID =
+        new BrokerConfiguration(true, true, false, false);
+    private MemoryRetainedRepository retainedRepository;
+    private MemoryQueueRepository queueRepository;
+
+    @Before
+    public void setUp() {
+        sessionRegistry = initPostOfficeAndSubsystems();
+
+        mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID), singletonMap(TEST_USER, TEST_PWD));
+        connection = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID);
+
+        connectMessage = ConnectionTestUtils.buildConnect(FAKE_CLIENT_ID);
+    }
+
+    private MQTTConnection createMQTTConnection(BrokerConfiguration config) {
+        channel = new EmbeddedChannel();
+        return createMQTTConnection(config, channel);
+    }
+
+    private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
+        return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, sut);
+    }
+
+    private SessionRegistry initPostOfficeAndSubsystems() {
+        subscriptions = new CTrieSubscriptionDirectory();
+        ISubscriptionsRepository subscriptionsRepository = new MemorySubscriptionsRepository();
+        subscriptions.init(subscriptionsRepository);
+        retainedRepository = new MemoryRetainedRepository();
+        queueRepository = new MemoryQueueRepository();
+
+        final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
+        final Authorizator permitAll = new Authorizator(authorizatorPolicy);
+        SessionRegistry sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+        return sessionRegistry;
+    }
+
+    @Test
+    public void testPublishQoS0ToItself() {
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+
+        // subscribe
+        subscribe(AT_MOST_ONCE, NEWS_TOPIC, connection);
+
+        // Exercise
+        final ByteBuf payload = Unpooled.copiedBuffer("Hello world!", Charset.defaultCharset());
+        sut.receivedPublishQos0(new Topic(NEWS_TOPIC), TEST_USER, FAKE_CLIENT_ID, payload, false,
+            MqttMessageBuilders.publish()
+                .payload(payload.retainedDuplicate())
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .retained(false)
+                .topicName(NEWS_TOPIC).build());
+
+        // Verify
+        ConnectionTestUtils.verifyReceivePublish(channel, NEWS_TOPIC, "Hello world!");
+    }
+
+    @Test
+    public void testForceClientDisconnection_issue116() {
+        final MQTTConnection clientXA = connectAs("subscriber");
+        subscribe(clientXA, NEWS_TOPIC, AT_MOST_ONCE);
+
+        final MQTTConnection clientXB = connectAs("publisher");
+        final ByteBuf anyPayload = Unpooled.copiedBuffer("Hello", Charset.defaultCharset());
+        sut.receivedPublishQos2(clientXB, MqttMessageBuilders.publish()
+            .payload(anyPayload)
+            .qos(MqttQoS.EXACTLY_ONCE)
+            .retained(false)
+            .topicName(NEWS_TOPIC).build(), "username");
+
+        final MQTTConnection clientYA = connectAs("subscriber");
+        subscribe(clientYA, NEWS_TOPIC, AT_MOST_ONCE);
+
+        final MQTTConnection clientYB = connectAs("publisher");
+        final ByteBuf anyPayload2 = Unpooled.copiedBuffer("Hello 2", Charset.defaultCharset());
+        sut.receivedPublishQos2(clientYB, MqttMessageBuilders.publish()
+            .payload(anyPayload2)
+            .qos(MqttQoS.EXACTLY_ONCE)
+            .retained(true)
+            .topicName(NEWS_TOPIC).build(), "username");
+
+        // Verify
+        assertFalse("First 'subscriber' channel MUST be closed by the broker", clientXA.channel.isOpen());
+        ConnectionTestUtils.verifyPublishIsReceived((EmbeddedChannel) clientYA.channel, AT_MOST_ONCE, "Hello 2");
+    }
+
+    private MQTTConnection connectAs(String clientId) {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        MQTTConnection connection = createMQTTConnection(CONFIG, channel);
+        connection.processConnect(ConnectionTestUtils.buildConnect(clientId));
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        return connection;
+    }
+
+    private void subscribe(MqttQoS topic, String newsTopic, MQTTConnection connection) {
+        MqttSubscribeMessage subscribe = MqttMessageBuilders.subscribe()
+            .addSubscription(topic, newsTopic)
+            .messageId(1)
+            .build();
+        sut.subscribeClientToTopics(subscribe, connection.getClientId(), null, this.connection);
+
+        MqttSubAckMessage subAck = ((EmbeddedChannel) this.connection.channel).readOutbound();
+        assertEquals(topic.value(), (int) subAck.payload().grantedQoSLevels().get(0));
+    }
+
+    protected void subscribe(MQTTConnection connection, String topic, MqttQoS desiredQos) {
+        EmbeddedChannel channel = (EmbeddedChannel) connection.channel;
+        MqttSubscribeMessage subscribe = MqttMessageBuilders.subscribe()
+            .addSubscription(desiredQos, topic)
+            .messageId(1)
+            .build();
+        sut.subscribeClientToTopics(subscribe, connection.getClientId(), null, connection);
+
+        MqttSubAckMessage subAck = channel.readOutbound();
+        assertEquals(desiredQos.value(), (int) subAck.payload().grantedQoSLevels().get(0));
+
+        final String clientId = connection.getClientId();
+        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
+
+        final Set<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
+        assertEquals(1, matchedSubscriptions.size());
+        final Subscription onlyMatchedSubscription = matchedSubscriptions.iterator().next();
+        assertEquals(expectedSubscription, onlyMatchedSubscription);
+    }
+
+    @Test
+    public void testPublishToMultipleSubscribers() {
+        final Set<String> clientIds = new HashSet<>(Arrays.asList(FAKE_CLIENT_ID, FAKE_CLIENT_ID2));
+        mockAuthenticator = new MockAuthenticator(clientIds, singletonMap(TEST_USER, TEST_PWD));
+        EmbeddedChannel channel1 = new EmbeddedChannel();
+        MQTTConnection connection1 = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID, channel1);
+        connection1.processConnect(ConnectionTestUtils.buildConnect(FAKE_CLIENT_ID));
+        ConnectionTestUtils.assertConnectAccepted(channel1);
+
+        EmbeddedChannel channel2 = new EmbeddedChannel();
+        MQTTConnection connection2 = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID, channel2);
+        connection2.processConnect(ConnectionTestUtils.buildConnect(FAKE_CLIENT_ID2));
+        ConnectionTestUtils.assertConnectAccepted(channel2);
+
+        // subscribe
+        final MqttQoS qos = AT_MOST_ONCE;
+        final String newsTopic = NEWS_TOPIC;
+        subscribe(qos, newsTopic, connection1);
+        subscribe(qos, newsTopic, connection2);
+
+        // Exercise
+        final ByteBuf payload = Unpooled.copiedBuffer("Hello world!", Charset.defaultCharset());
+        sut.receivedPublishQos0(new Topic(NEWS_TOPIC), TEST_USER, FAKE_CLIENT_ID, payload, false,
+            MqttMessageBuilders.publish()
+                .payload(payload.retainedDuplicate())
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .retained(false)
+                .topicName(NEWS_TOPIC).build());
+
+        // Verify
+        ConnectionTestUtils.verifyReceivePublish(channel1, NEWS_TOPIC, "Hello world!");
+        ConnectionTestUtils.verifyReceivePublish(channel2, NEWS_TOPIC, "Hello world!");
+    }
+
+    @Test
+    public void testPublishWithEmptyPayloadClearRetainedStore() {
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+
+        this.retainedRepository.retain(new Topic(NEWS_TOPIC), MqttMessageBuilders.publish()
+            .payload(ByteBufUtil.writeAscii(UnpooledByteBufAllocator.DEFAULT, "Hello world!"))
+            .qos(AT_LEAST_ONCE)
+            .build());
+
+        // Exercise
+        final ByteBuf anyPayload = Unpooled.copiedBuffer("Any payload", Charset.defaultCharset());
+        sut.receivedPublishQos0(new Topic(NEWS_TOPIC), TEST_USER, FAKE_CLIENT_ID, anyPayload, true,
+            MqttMessageBuilders.publish()
+                .payload(anyPayload)
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .retained(false)
+                .topicName(NEWS_TOPIC).build());
+
+        // Verify
+        assertTrue("QoS0 MUST clean retained message for topic", retainedRepository.isEmpty());
+    }
+
+    @Test
+    public void testPublishWithQoS1() {
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        subscribe(connection, NEWS_TOPIC, AT_LEAST_ONCE);
+
+        // Exercise
+        final ByteBuf anyPayload = Unpooled.copiedBuffer("Any payload", Charset.defaultCharset());
+        sut.receivedPublishQos1(connection, new Topic(NEWS_TOPIC), TEST_USER, anyPayload, 1, true,
+            MqttMessageBuilders.publish()
+                .payload(Unpooled.copiedBuffer("Any payload", Charset.defaultCharset()))
+                .qos(MqttQoS.AT_LEAST_ONCE)
+                .retained(true)
+                .topicName(NEWS_TOPIC).build());
+
+        // Verify
+        ConnectionTestUtils.verifyPublishIsReceived(channel, AT_LEAST_ONCE, "Any payload");
+    }
+
+    @Test
+    public void testPublishWithQoS2() {
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        subscribe(connection, NEWS_TOPIC, EXACTLY_ONCE);
+
+        // Exercise
+        final ByteBuf anyPayload = Unpooled.copiedBuffer("Any payload", Charset.defaultCharset());
+        sut.receivedPublishQos2(connection, MqttMessageBuilders.publish()
+                .payload(anyPayload)
+                .qos(MqttQoS.EXACTLY_ONCE)
+                .retained(true)
+                .topicName(NEWS_TOPIC).build(), "username");
+
+        // Verify
+        ConnectionTestUtils.verifyPublishIsReceived(channel, EXACTLY_ONCE, "Any payload");
+    }
+
+    // aka testPublishWithQoS1_notCleanSession
+    @Test
+    public void forwardQoS1PublishesWhenNotCleanSessionReconnects() {
+        connection.processConnect(ConnectionTestUtils.buildConnectNotClean(FAKE_CLIENT_ID));
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        subscribe(connection, NEWS_TOPIC, AT_LEAST_ONCE);
+        connection.processDisconnect(null);
+
+        // publish a QoS 1 message from another client publish a message on the topic
+        EmbeddedChannel pubChannel = new EmbeddedChannel();
+        MQTTConnection pubConn = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID, pubChannel);
+        pubConn.processConnect(ConnectionTestUtils.buildConnect(PUBLISHER_ID));
+        ConnectionTestUtils.assertConnectAccepted(pubChannel);
+
+        final ByteBuf anyPayload = Unpooled.copiedBuffer("Any payload", Charset.defaultCharset());
+        sut.receivedPublishQos1(pubConn, new Topic(NEWS_TOPIC), TEST_USER, anyPayload, 1, true,
+            MqttMessageBuilders.publish()
+                .payload(anyPayload.retainedDuplicate())
+                .qos(MqttQoS.AT_LEAST_ONCE)
+                .topicName(NEWS_TOPIC).build());
+
+        // simulate a reconnection from the other client
+        connection = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID);
+        connectMessage = ConnectionTestUtils.buildConnectNotClean(FAKE_CLIENT_ID);
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+
+        // Verify
+        ConnectionTestUtils.verifyPublishIsReceived(channel, AT_LEAST_ONCE, "Any payload");
+    }
+
+    @Test
+    public void checkReceivePublishedMessage_after_a_reconnect_with_notCleanSession() {
+        // first connect - subscribe -disconnect
+        connection.processConnect(ConnectionTestUtils.buildConnectNotClean(FAKE_CLIENT_ID));
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        subscribe(connection, NEWS_TOPIC, AT_LEAST_ONCE);
+        connection.processDisconnect(null);
+
+        // connect - subscribe from another connection but with same ClientID
+        EmbeddedChannel secondChannel = new EmbeddedChannel();
+        MQTTConnection secondConn = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID, secondChannel);
+        secondConn.processConnect(ConnectionTestUtils.buildConnect(FAKE_CLIENT_ID));
+        ConnectionTestUtils.assertConnectAccepted(secondChannel);
+        subscribe(secondConn, NEWS_TOPIC, AT_LEAST_ONCE);
+
+        // publish a QoS 1 message another client publish a message on the topic
+        EmbeddedChannel pubChannel = new EmbeddedChannel();
+        MQTTConnection pubConn = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID, pubChannel);
+        pubConn.processConnect(ConnectionTestUtils.buildConnect(PUBLISHER_ID));
+        ConnectionTestUtils.assertConnectAccepted(pubChannel);
+
+        final ByteBuf anyPayload = Unpooled.copiedBuffer("Any payload", Charset.defaultCharset());
+        sut.receivedPublishQos1(pubConn, new Topic(NEWS_TOPIC), TEST_USER, anyPayload, 1, true,
+            MqttMessageBuilders.publish()
+                .payload(anyPayload.retainedDuplicate())
+                .qos(MqttQoS.AT_LEAST_ONCE)
+                .topicName(NEWS_TOPIC).build());
+
+        // Verify that after a reconnection the client receive the message
+        ConnectionTestUtils.verifyPublishIsReceived(secondChannel, AT_LEAST_ONCE, "Any payload");
+    }
+
+    @Test
+    public void noPublishToInactiveSession() {
+        // create an inactive session for Subscriber
+        connection.processConnect(ConnectionTestUtils.buildConnectNotClean(SUBSCRIBER_ID));
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        subscribe(connection, NEWS_TOPIC, AT_LEAST_ONCE);
+        connection.processDisconnect(null);
+
+        // Exercise
+        EmbeddedChannel pubChannel = new EmbeddedChannel();
+        MQTTConnection pubConn = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID, pubChannel);
+        pubConn.processConnect(ConnectionTestUtils.buildConnect(PUBLISHER_ID));
+        ConnectionTestUtils.assertConnectAccepted(pubChannel);
+
+        final ByteBuf anyPayload = Unpooled.copiedBuffer("Any payload", Charset.defaultCharset());
+        sut.receivedPublishQos1(pubConn, new Topic(NEWS_TOPIC), TEST_USER, anyPayload, 1, true,
+            MqttMessageBuilders.publish()
+                .payload(anyPayload)
+                .qos(MqttQoS.AT_LEAST_ONCE)
+                .retained(true)
+                .topicName(NEWS_TOPIC).build());
+
+        verifyNoPublishIsReceived(channel);
+    }
+
+    private void verifyNoPublishIsReceived(EmbeddedChannel channel) {
+        final Object messageReceived = channel.readOutbound();
+        assertNull("Received an out message from processor while not expected", messageReceived);
+    }
+
+    @Test
+    public void cleanRetainedMessageStoreWhenPublishWithRetainedQos0IsReceived() {
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+
+        // publish a QoS1 retained message
+        final ByteBuf anyPayload = Unpooled.copiedBuffer("Any payload", Charset.defaultCharset());
+        final MqttPublishMessage publishMsg = MqttMessageBuilders.publish()
+            .payload(Unpooled.copiedBuffer("Any payload", Charset.defaultCharset()))
+            .qos(MqttQoS.AT_LEAST_ONCE)
+            .retained(true)
+            .topicName(NEWS_TOPIC)
+            .build();
+        sut.receivedPublishQos1(connection, new Topic(NEWS_TOPIC), TEST_USER, anyPayload, 1, true,
+                                publishMsg);
+
+        assertMessageIsRetained(NEWS_TOPIC, anyPayload);
+
+        // publish a QoS0 retained message
+        // Exercise
+        final ByteBuf qos0Payload = Unpooled.copiedBuffer("QoS0 payload", Charset.defaultCharset());
+        sut.receivedPublishQos0(new Topic(NEWS_TOPIC), TEST_USER, connection.getClientId(), qos0Payload, true,
+            MqttMessageBuilders.publish()
+                .payload(qos0Payload)
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .retained(false)
+                .topicName(NEWS_TOPIC).build());
+
+        // Verify
+        assertTrue("Retained message for topic /news must be cleared", retainedRepository.isEmpty());
+    }
+
+    private void assertMessageIsRetained(String expectedTopicName, ByteBuf expectedPayload) {
+        List<RetainedMessage> msgs = retainedRepository.retainedOnTopic(expectedTopicName);
+        assertEquals(1, msgs.size());
+        RetainedMessage msg = msgs.get(0);
+        assertEquals(ByteBufUtil.hexDump(expectedPayload), ByteBufUtil.hexDump(msg.getPayload()));
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/PostOfficeSubscribeTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/PostOfficeSubscribeTest.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.security.IAuthenticator;
+import com.echostreams.pulsar.mqtt.broker.security.IAuthorizatorPolicy;
+import com.echostreams.pulsar.mqtt.broker.security.PermitAllAuthorizatorPolicy;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.CTrieSubscriptionDirectory;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.ISubscriptionsDirectory;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import com.echostreams.pulsar.mqtt.persistence.MemorySubscriptionsRepository;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Set;
+
+import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
+import static io.netty.handler.codec.mqtt.MqttQoS.AT_MOST_ONCE;
+import static io.netty.handler.codec.mqtt.MqttQoS.EXACTLY_ONCE;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PostOfficeSubscribeTest {
+
+    private static final String FAKE_CLIENT_ID = "FAKE_123";
+    private static final String TEST_USER = "fakeuser";
+    private static final String TEST_PWD = "fakepwd";
+    private static final String NEWS_TOPIC = "/news";
+    private static final String BAD_FORMATTED_TOPIC = "#MQTTClient";
+
+    private MQTTConnection connection;
+    private EmbeddedChannel channel;
+    private PostOffice sut;
+    private ISubscriptionsDirectory subscriptions;
+    public static final String FAKE_USER_NAME = "UnAuthUser";
+    private MqttConnectMessage connectMessage;
+    private IAuthenticator mockAuthenticator;
+    private SessionRegistry sessionRegistry;
+    public static final BrokerConfiguration CONFIG = new BrokerConfiguration(true, true, false, false);
+    private MemoryQueueRepository queueRepository;
+
+    @Before
+    public void setUp() {
+        connectMessage = MqttMessageBuilders.connect()
+            .clientId(FAKE_CLIENT_ID)
+            .build();
+
+        prepareSUT();
+        createMQTTConnection(CONFIG);
+    }
+
+    private void createMQTTConnection(BrokerConfiguration config) {
+        channel = new EmbeddedChannel();
+        connection = createMQTTConnection(config, channel);
+    }
+
+    private void prepareSUT() {
+        mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID), singletonMap(TEST_USER, TEST_PWD));
+
+        subscriptions = new CTrieSubscriptionDirectory();
+        ISubscriptionsRepository subscriptionsRepository = new MemorySubscriptionsRepository();
+        subscriptions.init(subscriptionsRepository);
+        queueRepository = new MemoryQueueRepository();
+
+        final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
+        final Authorizator permitAll = new Authorizator(authorizatorPolicy);
+        sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+    }
+
+    private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
+        return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, sut);
+    }
+
+    protected void connect() {
+        MqttConnectMessage connectMessage = MqttMessageBuilders.connect()
+            .clientId(FAKE_CLIENT_ID)
+            .build();
+        connection.processConnect(connectMessage);
+        MqttConnAckMessage connAck = channel.readOutbound();
+        assertEquals("Connect must be accepted", CONNECTION_ACCEPTED, connAck.variableHeader().connectReturnCode());
+    }
+
+    @Test
+    public void testSubscribe() {
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+
+        // Exercise & verify
+        subscribe(channel, NEWS_TOPIC, AT_MOST_ONCE);
+    }
+
+    protected void subscribe(EmbeddedChannel channel, String topic, MqttQoS desiredQos) {
+        MqttSubscribeMessage subscribe = MqttMessageBuilders.subscribe()
+            .addSubscription(desiredQos, topic)
+            .messageId(1)
+            .build();
+        sut.subscribeClientToTopics(subscribe, FAKE_CLIENT_ID, null, connection);
+
+        MqttSubAckMessage subAck = channel.readOutbound();
+        assertEquals(desiredQos.value(), (int) subAck.payload().grantedQoSLevels().get(0));
+
+        final String clientId = NettyUtils.clientID(channel);
+        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
+
+        final Set<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
+        assertEquals(1, matchedSubscriptions.size());
+        final Subscription onlyMatchedSubscription = matchedSubscriptions.iterator().next();
+        assertEquals(expectedSubscription, onlyMatchedSubscription);
+    }
+
+    protected void subscribe(MQTTConnection connection, String topic, MqttQoS desiredQos) {
+        EmbeddedChannel channel = (EmbeddedChannel) connection.channel;
+        MqttSubscribeMessage subscribe = MqttMessageBuilders.subscribe()
+            .addSubscription(desiredQos, topic)
+            .messageId(1)
+            .build();
+        sut.subscribeClientToTopics(subscribe, connection.getClientId(), null, connection);
+
+        MqttSubAckMessage subAck = channel.readOutbound();
+        assertEquals(desiredQos.value(), (int) subAck.payload().grantedQoSLevels().get(0));
+
+        final String clientId = connection.getClientId();
+        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
+
+        final Set<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
+        assertEquals(1, matchedSubscriptions.size());
+        final Subscription onlyMatchedSubscription = matchedSubscriptions.iterator().next();
+        assertEquals(expectedSubscription, onlyMatchedSubscription);
+    }
+
+    @Test
+    public void testSubscribedToNotAuthorizedTopic() {
+        NettyUtils.userName(channel, FAKE_USER_NAME);
+
+        IAuthorizatorPolicy prohibitReadOnNewsTopic = mock(IAuthorizatorPolicy.class);
+        when(prohibitReadOnNewsTopic.canRead(eq(new Topic(NEWS_TOPIC)), eq(FAKE_USER_NAME), eq(FAKE_CLIENT_ID)))
+            .thenReturn(false);
+
+        sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, new Authorizator(prohibitReadOnNewsTopic));
+
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+
+        //Exercise
+        MqttSubscribeMessage subscribe = MqttMessageBuilders.subscribe()
+            .addSubscription(AT_MOST_ONCE, NEWS_TOPIC)
+            .messageId(1)
+            .build();
+        sut.subscribeClientToTopics(subscribe, FAKE_CLIENT_ID, FAKE_USER_NAME, connection);
+
+        // Verify
+        MqttSubAckMessage subAckMsg = channel.readOutbound();
+        verifyFailureQos(subAckMsg);
+    }
+
+    private void verifyFailureQos(MqttSubAckMessage subAckMsg) {
+        List<Integer> grantedQoSes = subAckMsg.payload().grantedQoSLevels();
+        assertEquals(1, grantedQoSes.size());
+        assertTrue(grantedQoSes.contains(MqttQoS.FAILURE.value()));
+    }
+
+    @Test
+    public void testDoubleSubscribe() {
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        assertEquals("After CONNECT subscription MUST be empty", 0, subscriptions.size());
+        subscribe(channel, NEWS_TOPIC, AT_MOST_ONCE);
+        assertEquals("After /news subscribe, subscription MUST contain it", 1, subscriptions.size());
+
+        //Exercise & verify
+        subscribe(channel, NEWS_TOPIC, AT_MOST_ONCE);
+    }
+
+    @Test
+    public void testSubscribeWithBadFormattedTopic() {
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        assertEquals("After CONNECT subscription MUST be empty", 0, subscriptions.size());
+
+        //Exercise
+        MqttSubscribeMessage subscribe = MqttMessageBuilders.subscribe()
+            .addSubscription(AT_MOST_ONCE, BAD_FORMATTED_TOPIC)
+            .messageId(1)
+            .build();
+        this.sut.subscribeClientToTopics(subscribe, FAKE_CLIENT_ID, FAKE_USER_NAME, connection);
+        MqttSubAckMessage subAckMsg = channel.readOutbound();
+
+        assertEquals("Bad topic CAN'T add any subscription", 0, subscriptions.size());
+        verifyFailureQos(subAckMsg);
+    }
+
+    @Test
+    public void testCleanSession_maintainClientSubscriptions() {
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        assertEquals("After CONNECT subscription MUST be empty", 0, subscriptions.size());
+
+        subscribe(channel, NEWS_TOPIC, AT_MOST_ONCE);
+
+        assertEquals("Subscribe MUST contain one subscription", 1, subscriptions.size());
+
+        connection.processDisconnect(null);
+        assertEquals("Disconnection MUSTN'T clear subscriptions", 1, subscriptions.size());
+
+        EmbeddedChannel anotherChannel = new EmbeddedChannel();
+        MQTTConnection anotherConn = createMQTTConnection(PostOfficePublishTest.ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID, anotherChannel);
+        anotherConn.processConnect(ConnectionTestUtils.buildConnect(FAKE_CLIENT_ID));
+        ConnectionTestUtils.assertConnectAccepted(anotherChannel);
+        assertEquals("After a reconnect, subscription MUST be still present", 1, subscriptions.size());
+
+        final ByteBuf payload = Unpooled.copiedBuffer("Hello world!", Charset.defaultCharset());
+        sut.receivedPublishQos0(new Topic(NEWS_TOPIC), TEST_USER, TEST_PWD, payload, false,
+            MqttMessageBuilders.publish()
+                .payload(payload.retainedDuplicate())
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .retained(false)
+                .topicName(NEWS_TOPIC).build());
+
+        ConnectionTestUtils.verifyPublishIsReceived(anotherChannel, AT_MOST_ONCE, "Hello world!");
+    }
+
+    /**
+     * Check that after a client has connected with clean session false, subscribed to some topic
+     * and exited, if it reconnects with clean session true, the broker correctly cleanup every
+     * previous subscription
+     */
+    @Test
+    public void testCleanSession_correctlyClientSubscriptions() {
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        assertEquals("After CONNECT subscription MUST be empty", 0, subscriptions.size());
+
+        //subscribe(channel, NEWS_TOPIC, AT_MOST_ONCE);
+        final MqttSubscribeMessage subscribeMsg = MqttMessageBuilders
+            .subscribe()
+            .addSubscription(AT_MOST_ONCE, NEWS_TOPIC)
+            .messageId(1)
+            .build();
+        connection.processSubscribe(subscribeMsg);
+        assertEquals("Subscribe MUST contain one subscription", 1, subscriptions.size());
+
+        connection.processDisconnect(null);
+        assertEquals("Disconnection MUSTN'T clear subscriptions", 1, subscriptions.size());
+
+        connectMessage = MqttMessageBuilders.connect()
+            .clientId(FAKE_CLIENT_ID)
+            .cleanSession(true)
+            .build();
+        channel = new EmbeddedChannel();
+        connection = createMQTTConnection(CONFIG, channel);
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        assertEquals("After CONNECT with clean, subscription MUST be empty", 0, subscriptions.size());
+
+        // publish on /news
+        final ByteBuf payload = Unpooled.copiedBuffer("Hello world!", Charset.defaultCharset());
+        sut.receivedPublishQos0(new Topic(NEWS_TOPIC), TEST_USER, TEST_PWD, payload, false,
+            MqttMessageBuilders.publish()
+                .payload(payload)
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .retained(false)
+                .topicName(NEWS_TOPIC).build());
+
+        // verify no publish is fired
+        ConnectionTestUtils.verifyNoPublishIsReceived(channel);
+    }
+
+    @Test
+    public void testReceiveRetainedPublishRespectingSubscriptionQoSAndNotPublisher() {
+        // publisher publish a retained message on topic /news
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        final ByteBuf payload = Unpooled.copiedBuffer("Hello world!", Charset.defaultCharset());
+        final MqttPublishMessage retainedPubQoS1Msg = MqttMessageBuilders.publish()
+            .payload(payload.retainedDuplicate())
+            .qos(MqttQoS.AT_LEAST_ONCE)
+            .topicName(NEWS_TOPIC).build();
+        sut.receivedPublishQos1(connection, new Topic(NEWS_TOPIC), TEST_USER, payload, 1, true,
+            retainedPubQoS1Msg);
+
+        // subscriber connects subscribe to topic /news and receive the last retained message
+        EmbeddedChannel subChannel = new EmbeddedChannel();
+        MQTTConnection subConn = createMQTTConnection(PostOfficePublishTest.ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID, subChannel);
+        subConn.processConnect(ConnectionTestUtils.buildConnect(PostOfficePublishTest.SUBSCRIBER_ID));
+        ConnectionTestUtils.assertConnectAccepted(subChannel);
+        subscribe(subConn, NEWS_TOPIC, MqttQoS.AT_MOST_ONCE);
+
+        // Verify publish is received
+        ConnectionTestUtils.verifyReceiveRetainedPublish(subChannel, NEWS_TOPIC, "Hello world!", MqttQoS.AT_MOST_ONCE);
+    }
+
+    @Test
+    public void testLowerTheQosToTheRequestedBySubscription() {
+        Subscription subQos1 = new Subscription("Sub A", new Topic("a/b"), MqttQoS.AT_LEAST_ONCE);
+        assertEquals(MqttQoS.AT_LEAST_ONCE, PostOffice.lowerQosToTheSubscriptionDesired(subQos1, EXACTLY_ONCE));
+
+        Subscription subQos2 = new Subscription("Sub B", new Topic("a/+"), EXACTLY_ONCE);
+        assertEquals(EXACTLY_ONCE, PostOffice.lowerQosToTheSubscriptionDesired(subQos2, EXACTLY_ONCE));
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/PostOfficeSubscribeTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/PostOfficeSubscribeTest.java
@@ -22,6 +22,7 @@ import com.echostreams.pulsar.mqtt.broker.subscriptions.CTrieSubscriptionDirecto
 import com.echostreams.pulsar.mqtt.broker.subscriptions.ISubscriptionsDirectory;
 import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
 import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import com.echostreams.pulsar.mqtt.broker.utils.NettyUtils;
 import com.echostreams.pulsar.mqtt.persistence.MemorySubscriptionsRepository;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/PostOfficeUnsubscribeTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/PostOfficeUnsubscribeTest.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.security.IAuthenticator;
+import com.echostreams.pulsar.mqtt.broker.security.PermitAllAuthorizatorPolicy;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.CTrieSubscriptionDirectory;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.ISubscriptionsDirectory;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import com.echostreams.pulsar.mqtt.persistence.MemorySubscriptionsRepository;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.Set;
+
+import static io.netty.handler.codec.mqtt.MqttQoS.*;
+import static java.util.Collections.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class PostOfficeUnsubscribeTest {
+
+    private static final String FAKE_CLIENT_ID = "FAKE_123";
+    private static final String TEST_USER = "fakeuser";
+    private static final String TEST_PWD = "fakepwd";
+    static final String NEWS_TOPIC = "/news";
+    private static final String BAD_FORMATTED_TOPIC = "#MQTTClient";
+
+    private MQTTConnection connection;
+    private EmbeddedChannel channel;
+    private PostOffice sut;
+    private ISubscriptionsDirectory subscriptions;
+    private MqttConnectMessage connectMessage;
+    private IAuthenticator mockAuthenticator;
+    private SessionRegistry sessionRegistry;
+    public static final BrokerConfiguration CONFIG = new BrokerConfiguration(true, true, false, false);
+    private MemoryQueueRepository queueRepository;
+
+    @Before
+    public void setUp() {
+        connectMessage = MqttMessageBuilders.connect()
+            .clientId(FAKE_CLIENT_ID)
+            .build();
+
+        prepareSUT();
+        createMQTTConnection(CONFIG);
+    }
+
+    private void createMQTTConnection(BrokerConfiguration config) {
+        channel = new EmbeddedChannel();
+        connection = createMQTTConnection(config, channel);
+    }
+
+    private void prepareSUT() {
+        mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID), singletonMap(TEST_USER, TEST_PWD));
+
+        subscriptions = new CTrieSubscriptionDirectory();
+        ISubscriptionsRepository subscriptionsRepository = new MemorySubscriptionsRepository();
+        subscriptions.init(subscriptionsRepository);
+        queueRepository = new MemoryQueueRepository();
+
+        final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
+        final Authorizator permitAll = new Authorizator(authorizatorPolicy);
+        sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+    }
+
+    private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
+        return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, sut);
+    }
+
+    protected void connect(MQTTConnection connection, String clientId) {
+        MqttConnectMessage connectMessage = ConnectionTestUtils.buildConnect(clientId);
+        connect(connection, connectMessage);
+    }
+
+    protected void connect(MQTTConnection connection, MqttConnectMessage connectMessage) {
+        connection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted((EmbeddedChannel) connection.channel);
+    }
+
+    protected void subscribe(MQTTConnection connection, String topic, MqttQoS desiredQos) {
+        EmbeddedChannel channel = (EmbeddedChannel) connection.channel;
+        MqttSubscribeMessage subscribe = MqttMessageBuilders.subscribe()
+            .addSubscription(desiredQos, topic)
+            .messageId(1)
+            .build();
+        sut.subscribeClientToTopics(subscribe, connection.getClientId(), null, connection);
+
+        MqttSubAckMessage subAck = channel.readOutbound();
+        assertEquals(desiredQos.value(), (int) subAck.payload().grantedQoSLevels().get(0));
+
+        final String clientId = connection.getClientId();
+        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
+
+        final Set<Subscription> matchedSubscriptions = subscriptions.matchQosSharpening(new Topic(topic));
+        assertEquals(1, matchedSubscriptions.size());
+        //assertTrue(matchedSubscriptions.size() >=1);
+        final Subscription onlyMatchedSubscription = matchedSubscriptions.iterator().next();
+        assertEquals(expectedSubscription, onlyMatchedSubscription);
+
+//        assertTrue(matchedSubscriptions.contains(expectedSubscription));
+    }
+
+    @Test
+    public void testUnsubscribeWithBadFormattedTopic() {
+        connect(this.connection, FAKE_CLIENT_ID);
+
+        // Exercise
+        sut.unsubscribe(singletonList(BAD_FORMATTED_TOPIC), connection, 1);
+
+        // Verify
+        assertFalse("Unsubscribe with bad topic MUST close drop the connection, (issue 68)", channel.isOpen());
+    }
+
+    @Test
+    public void testDontNotifyClientSubscribedToTopicAfterDisconnectedAndReconnectOnSameChannel() {
+        connect(this.connection, FAKE_CLIENT_ID);
+        subscribe(connection, NEWS_TOPIC, AT_MOST_ONCE);
+
+        // publish on /news
+        final ByteBuf payload = Unpooled.copiedBuffer("Hello world!", Charset.defaultCharset());
+        sut.receivedPublishQos0(new Topic(NEWS_TOPIC), TEST_USER, TEST_PWD, payload, false,
+            MqttMessageBuilders.publish()
+                .payload(payload.retainedDuplicate())
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .retained(false)
+                .topicName(NEWS_TOPIC).build());
+
+        ConnectionTestUtils.verifyPublishIsReceived(channel, AT_MOST_ONCE, "Hello world!");
+
+        unsubscribeAndVerifyAck(NEWS_TOPIC);
+
+        // publish on /news
+        final ByteBuf payload2 = Unpooled.copiedBuffer("Hello world!", Charset.defaultCharset());
+        sut.receivedPublishQos0(new Topic(NEWS_TOPIC), TEST_USER, TEST_PWD, payload2, false,
+            MqttMessageBuilders.publish()
+                .payload(payload)
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .retained(false)
+                .topicName(NEWS_TOPIC).build());
+
+        ConnectionTestUtils.verifyNoPublishIsReceived(channel);
+    }
+
+    protected void unsubscribeAndVerifyAck(String topic) {
+        final int messageId = 1;
+
+        sut.unsubscribe(Collections.singletonList(topic), connection, messageId);
+
+        MqttUnsubAckMessage unsubAckMessageAck = channel.readOutbound();
+        assertEquals("Unsubscribe must be accepted", messageId, unsubAckMessageAck.variableHeader().messageId());
+    }
+
+    @Test
+    public void testDontNotifyClientSubscribedToTopicAfterDisconnectedAndReconnectOnNewChannel() {
+        connect(this.connection, FAKE_CLIENT_ID);
+        subscribe(connection, NEWS_TOPIC, AT_MOST_ONCE);
+        // publish on /news
+        final ByteBuf payload = Unpooled.copiedBuffer("Hello world!", Charset.defaultCharset());
+        sut.receivedPublishQos0(new Topic(NEWS_TOPIC), TEST_USER, TEST_PWD, payload, false,
+            MqttMessageBuilders.publish()
+                .payload(payload.retainedDuplicate())
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .retained(false)
+                .topicName(NEWS_TOPIC).build());
+
+        ConnectionTestUtils.verifyPublishIsReceived(channel, AT_MOST_ONCE, "Hello world!");
+
+        unsubscribeAndVerifyAck(NEWS_TOPIC);
+        connection.processDisconnect(null);
+
+        // connect on another channel
+        EmbeddedChannel anotherChannel = new EmbeddedChannel();
+        MQTTConnection anotherConnection = createMQTTConnection(CONFIG, anotherChannel);
+        anotherConnection.processConnect(connectMessage);
+        ConnectionTestUtils.assertConnectAccepted(anotherChannel);
+
+        // publish on /news
+        final ByteBuf payload2 = Unpooled.copiedBuffer("Hello world!", Charset.defaultCharset());
+        sut.receivedPublishQos0(new Topic(NEWS_TOPIC), TEST_USER, TEST_PWD, payload2, false,
+            MqttMessageBuilders.publish()
+                .payload(payload2)
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .retained(false)
+                .topicName(NEWS_TOPIC).build());
+
+        ConnectionTestUtils.verifyNoPublishIsReceived(anotherChannel);
+    }
+
+    @Test
+    public void avoidMultipleNotificationsAfterMultipleReconnection_cleanSessionFalseQoS1() {
+        final MqttConnectMessage notCleanConnect = ConnectionTestUtils.buildConnectNotClean(FAKE_CLIENT_ID);
+        connect(connection, notCleanConnect);
+        subscribe(connection, NEWS_TOPIC, AT_LEAST_ONCE);
+        connection.processDisconnect(null);
+
+        // connect on another channel
+        final String firstPayload = "Hello MQTT 1";
+        connectPublishDisconnectFromAnotherClient(firstPayload, NEWS_TOPIC);
+
+        // reconnect FAKE_CLIENT on another channel
+        EmbeddedChannel anotherChannel2 = new EmbeddedChannel();
+        MQTTConnection anotherConnection2 = createMQTTConnection(CONFIG, anotherChannel2);
+        anotherConnection2.processConnect(notCleanConnect);
+        ConnectionTestUtils.assertConnectAccepted(anotherChannel2);
+
+        ConnectionTestUtils.verifyPublishIsReceived(anotherChannel2, MqttQoS.AT_LEAST_ONCE, firstPayload);
+
+        anotherConnection2.processDisconnect(null);
+
+        final String secondPayload = "Hello MQTT 2";
+        connectPublishDisconnectFromAnotherClient(secondPayload, NEWS_TOPIC);
+
+        EmbeddedChannel anotherChannel3 = new EmbeddedChannel();
+        MQTTConnection anotherConnection3 = createMQTTConnection(CONFIG, anotherChannel3);
+        anotherConnection3.processConnect(notCleanConnect);
+        ConnectionTestUtils.assertConnectAccepted(anotherChannel3);
+
+        ConnectionTestUtils.verifyPublishIsReceived(anotherChannel3, MqttQoS.AT_LEAST_ONCE, secondPayload);
+    }
+
+    private void connectPublishDisconnectFromAnotherClient(String firstPayload, String topic) {
+        MQTTConnection anotherConnection = connectNotCleanAs(PostOfficePublishTest.PUBLISHER_ID);
+
+        // publish from another channel
+        final ByteBuf anyPayload = Unpooled.copiedBuffer(firstPayload, Charset.defaultCharset());
+        sut.receivedPublishQos1(anotherConnection, new Topic(topic), TEST_USER, anyPayload, 1, false,
+            MqttMessageBuilders.publish()
+                .payload(Unpooled.copiedBuffer(firstPayload, Charset.defaultCharset()))
+                .qos(MqttQoS.AT_LEAST_ONCE)
+                .retained(false)
+                .topicName(topic).build());
+
+        // disconnect the other channel
+        anotherConnection.processDisconnect(null);
+    }
+
+    private MQTTConnection connectNotCleanAs(String clientId) {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        MQTTConnection connection = createMQTTConnection(CONFIG, channel);
+        connection.processConnect(ConnectionTestUtils.buildConnectNotClean(clientId));
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        return connection;
+    }
+
+    private MQTTConnection connectAs(String clientId) {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        MQTTConnection connection = createMQTTConnection(CONFIG, channel);
+        connection.processConnect(ConnectionTestUtils.buildConnect(clientId));
+        ConnectionTestUtils.assertConnectAccepted(channel);
+        return connection;
+    }
+
+    @Test
+    public void testConnectSubPub_cycle_getTimeout_on_second_disconnect_issue142() {
+        connect(connection, FAKE_CLIENT_ID);
+        subscribe(connection, NEWS_TOPIC, AT_MOST_ONCE);
+        // publish on /news
+        final ByteBuf payload = Unpooled.copiedBuffer("Hello world!", Charset.defaultCharset());
+        sut.receivedPublishQos0(new Topic(NEWS_TOPIC), TEST_USER, TEST_PWD, payload, false,
+            MqttMessageBuilders.publish()
+                .payload(payload.retainedDuplicate())
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .retained(false)
+                .topicName(NEWS_TOPIC).build());
+
+        ConnectionTestUtils.verifyPublishIsReceived((EmbeddedChannel) connection.channel, AT_MOST_ONCE, "Hello world!");
+
+        connection.processDisconnect(null);
+
+        final MqttConnectMessage notCleanConnect = ConnectionTestUtils.buildConnect(FAKE_CLIENT_ID);
+        EmbeddedChannel subscriberChannel = new EmbeddedChannel();
+        MQTTConnection subscriberConnection = createMQTTConnection(CONFIG, subscriberChannel);
+        subscriberConnection.processConnect(notCleanConnect);
+        ConnectionTestUtils.assertConnectAccepted(subscriberChannel);
+
+        subscribe(subscriberConnection, NEWS_TOPIC, AT_MOST_ONCE);
+        // publish on /news
+        final ByteBuf payload2 = Unpooled.copiedBuffer("Hello world2!", Charset.defaultCharset());
+        sut.receivedPublishQos0(new Topic(NEWS_TOPIC), TEST_USER, TEST_PWD, payload2, false,
+            MqttMessageBuilders.publish()
+                .payload(payload2.retainedDuplicate())
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .retained(false)
+                .topicName(NEWS_TOPIC).build());
+
+        ConnectionTestUtils.verifyPublishIsReceived(subscriberChannel, AT_MOST_ONCE, "Hello world2!");
+
+        subscriberConnection.processDisconnect(null);
+
+        assertFalse("after a disconnect the client should be disconnected", subscriberChannel.isOpen());
+    }
+
+    @Test
+    public void checkReplayofStoredPublishResumeAfter_a_disconnect_cleanSessionFalseQoS1() {
+        final MQTTConnection publisher = connectAs("Publisher");
+
+        connect(this.connection, FAKE_CLIENT_ID);
+        subscribe(connection, NEWS_TOPIC, AT_LEAST_ONCE);
+
+        // publish from another channel
+        publishQos1(publisher, NEWS_TOPIC, "Hello world MQTT!!-1", 99);
+        ConnectionTestUtils.verifyPublishIsReceived(channel, AT_LEAST_ONCE, "Hello world MQTT!!-1");
+        connection.processDisconnect(null);
+
+        publishQos1(publisher, NEWS_TOPIC, "Hello world MQTT!!-2", 100);
+        publishQos1(publisher, NEWS_TOPIC, "Hello world MQTT!!-3", 101);
+
+        createMQTTConnection(CONFIG);
+        connect(this.connection, FAKE_CLIENT_ID);
+        ConnectionTestUtils.verifyPublishIsReceived(channel, AT_LEAST_ONCE, "Hello world MQTT!!-2");
+        ConnectionTestUtils.verifyPublishIsReceived(channel, AT_LEAST_ONCE, "Hello world MQTT!!-3");
+    }
+
+    private void publishQos1(MQTTConnection publisher, String topic, String payload, int messageID) {
+        final ByteBuf bytePayload = Unpooled.copiedBuffer(payload, Charset.defaultCharset());
+        sut.receivedPublishQos1(publisher, new Topic(topic), TEST_USER, bytePayload, messageID, false,
+            MqttMessageBuilders.publish()
+                .payload(Unpooled.copiedBuffer(payload, Charset.defaultCharset()))
+                .qos(MqttQoS.AT_LEAST_ONCE)
+                .retained(false)
+                .topicName(NEWS_TOPIC).build());
+    }
+
+    private void publishQos2(MQTTConnection connection, String topic, String payload) {
+        final ByteBuf bytePayload = Unpooled.copiedBuffer(payload, Charset.defaultCharset());
+        sut.receivedPublishQos2(connection, MqttMessageBuilders.publish()
+            .payload(bytePayload)
+            .qos(MqttQoS.EXACTLY_ONCE)
+            .retained(true)
+            .topicName(NEWS_TOPIC).build(), "username");
+    }
+
+    /**
+     * subscriber connect and subscribe on "topic" subscriber disconnects publisher connects and
+     * send two message "hello1" "hello2" to "topic" subscriber connects again and receive "hello1"
+     * "hello2"
+     */
+    @Test
+    public void checkQoS2SubscriberDisconnectReceivePersistedPublishes() {
+        connect(this.connection, FAKE_CLIENT_ID);
+        subscribe(connection, NEWS_TOPIC, EXACTLY_ONCE);
+        connection.processDisconnect(null);
+
+        final MQTTConnection publisher = connectAs("Publisher");
+        publishQos2(publisher, NEWS_TOPIC, "Hello world MQTT!!-1");
+        publishQos2(publisher, NEWS_TOPIC, "Hello world MQTT!!-2");
+
+        createMQTTConnection(CONFIG);
+        connect(this.connection, FAKE_CLIENT_ID);
+        ConnectionTestUtils.verifyPublishIsReceived(channel, EXACTLY_ONCE, "Hello world MQTT!!-1");
+        ConnectionTestUtils.verifyPublishIsReceived(channel, EXACTLY_ONCE, "Hello world MQTT!!-2");
+    }
+
+    /**
+     * subscriber connect and subscribe on "a/b" QoS 1 and "a/+" QoS 2 publisher connects and send a
+     * message "hello" on "a/b" subscriber must receive only a single message not twice
+     */
+    @Test
+    public void checkSinglePublishOnOverlappingSubscriptions() {
+        final MQTTConnection publisher = connectAs("Publisher");
+
+        connect(this.connection, FAKE_CLIENT_ID);
+        subscribe(connection, "a/b", AT_LEAST_ONCE);
+        subscribe(connection, "a/+", EXACTLY_ONCE);
+
+        // force the publisher to send
+        publishQos1(publisher, "a/b", "Hello world MQTT!!", 60);
+
+        ConnectionTestUtils.verifyPublishIsReceived(channel, AT_LEAST_ONCE, "Hello world MQTT!!");
+        ConnectionTestUtils.verifyNoPublishIsReceived(channel);
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/SessionRegistryTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/SessionRegistryTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.security.IAuthenticator;
+import com.echostreams.pulsar.mqtt.broker.security.PermitAllAuthorizatorPolicy;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.CTrieSubscriptionDirectory;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.ISubscriptionsDirectory;
+import com.echostreams.pulsar.mqtt.persistence.MemorySubscriptionsRepository;
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttVersion;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SessionRegistryTest {
+
+    static final String FAKE_CLIENT_ID = "FAKE_123";
+    static final String TEST_USER = "fakeuser";
+    static final String TEST_PWD = "fakepwd";
+
+    private MQTTConnection connection;
+    private EmbeddedChannel channel;
+    private SessionRegistry sut;
+    private MqttMessageBuilders.ConnectBuilder connMsg;
+    private static final BrokerConfiguration ALLOW_ANONYMOUS_AND_ZEROBYTE_CLIENT_ID =
+        new BrokerConfiguration(true, true, false, false);
+    private MemoryQueueRepository queueRepository;
+
+    @Before
+    public void setUp() {
+        connMsg = MqttMessageBuilders.connect().protocolVersion(MqttVersion.MQTT_3_1).cleanSession(true);
+
+        createMQTTConnection(ALLOW_ANONYMOUS_AND_ZEROBYTE_CLIENT_ID);
+    }
+
+    private void createMQTTConnection(BrokerConfiguration config) {
+        channel = new EmbeddedChannel();
+        connection = createMQTTConnection(config, channel);
+    }
+
+    private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
+        IAuthenticator mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID),
+                                                                 singletonMap(TEST_USER, TEST_PWD));
+
+        ISubscriptionsDirectory subscriptions = new CTrieSubscriptionDirectory();
+        ISubscriptionsRepository subscriptionsRepository = new MemorySubscriptionsRepository();
+        subscriptions.init(subscriptionsRepository);
+        queueRepository = new MemoryQueueRepository();
+
+        final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
+        final Authorizator permitAll = new Authorizator(authorizatorPolicy);
+        sut = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        final PostOffice postOffice = new PostOffice(subscriptions,
+            new MemoryRetainedRepository(), sut, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+        return new MQTTConnection(channel, config, mockAuthenticator, sut, postOffice);
+    }
+
+    @Test
+    public void testConnAckContainsSessionPresentFlag() {
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID)
+                                        .protocolVersion(MqttVersion.MQTT_3_1_1)
+                                        .build();
+        NettyUtils.clientID(channel, FAKE_CLIENT_ID);
+        NettyUtils.cleanSession(channel, false);
+
+        // Connect a first time
+        sut.bindToSession(connection, msg, FAKE_CLIENT_ID);
+        // disconnect
+        sut.disconnect(FAKE_CLIENT_ID);
+
+        // Exercise, reconnect
+        EmbeddedChannel anotherChannel = new EmbeddedChannel();
+        MQTTConnection anotherConnection = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZEROBYTE_CLIENT_ID, anotherChannel);
+        sut.bindToSession(anotherConnection, msg, FAKE_CLIENT_ID);
+
+        // Verify
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_ACCEPTED, anotherChannel.readOutbound());
+        assertTrue("Connection is accepted and therefore should remain open", anotherChannel.isOpen());
+    }
+
+    @Test
+    public void connectWithCleanSessionUpdateClientSession() {
+        // first connect with clean session true
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).cleanSession(true).build();
+        connection.processConnect(msg);
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
+        connection.processDisconnect(null);
+        assertFalse(channel.isOpen());
+
+        // second connect with clean session false
+        EmbeddedChannel anotherChannel = new EmbeddedChannel();
+        MQTTConnection anotherConnection = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZEROBYTE_CLIENT_ID,
+                                                                anotherChannel);
+        MqttConnectMessage secondConnMsg = MqttMessageBuilders.connect()
+            .clientId(FAKE_CLIENT_ID)
+            .protocolVersion(MqttVersion.MQTT_3_1)
+            .build();
+
+        anotherConnection.processConnect(secondConnMsg);
+        NettyChannelAssertions.assertEqualsConnAck(CONNECTION_ACCEPTED, anotherChannel.readOutbound());
+
+        // Verify client session is clean false
+        Session session = sut.retrieve(FAKE_CLIENT_ID);
+        assertFalse(session.isClean());
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/SessionRegistryTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/SessionRegistryTest.java
@@ -19,6 +19,7 @@ import com.echostreams.pulsar.mqtt.broker.security.IAuthenticator;
 import com.echostreams.pulsar.mqtt.broker.security.PermitAllAuthorizatorPolicy;
 import com.echostreams.pulsar.mqtt.broker.subscriptions.CTrieSubscriptionDirectory;
 import com.echostreams.pulsar.mqtt.broker.subscriptions.ISubscriptionsDirectory;
+import com.echostreams.pulsar.mqtt.broker.utils.NettyUtils;
 import com.echostreams.pulsar.mqtt.persistence.MemorySubscriptionsRepository;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/SessionTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/SessionTest.java
@@ -1,0 +1,50 @@
+package com.echostreams.pulsar.mqtt.broker;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import org.junit.Test;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SessionTest {
+
+    @Test
+    public void testPubAckDrainMessagesRemainingInQueue() {
+        final Queue<SessionRegistry.EnqueuedMessage> queuedMessages = new ConcurrentLinkedQueue<>();
+        final Session client = new Session("Subscriber", true, null, queuedMessages);
+        final EmbeddedChannel testChannel = new EmbeddedChannel();
+        BrokerConfiguration brokerConfiguration = new BrokerConfiguration(true, false, false, false);
+        MQTTConnection mqttConnection = new MQTTConnection(testChannel, brokerConfiguration, null, null, null);
+        client.markConnected();
+        client.bind(mqttConnection);
+
+        final Topic destinationTopic = new Topic("/a/b");
+        sendQoS1To(client, destinationTopic, "Hello World!");
+        // simulate a filling of inflight space and start pushing on queue
+        for (int i = 0; i < 10; i++) {
+            sendQoS1To(client, destinationTopic, "Hello World " + i + "!");
+        }
+
+        assertEquals("Inflight zone must be full, and the 11th message must be queued",
+            1, queuedMessages.size());
+        // Exercise
+        client.pubAckReceived(1);
+
+        // Verify
+        assertTrue("Messages should be drained", queuedMessages.isEmpty());
+    }
+
+    private void sendQoS1To(Session client, Topic destinationTopic, String message) {
+        final ByteBuf payload = ByteBufUtil.writeUtf8(UnpooledByteBufAllocator.DEFAULT, message);
+        client.sendPublishOnSessionAtQos(destinationTopic, MqttQoS.AT_LEAST_ONCE, payload);
+    }
+
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/config/ClasspathResourceLoaderTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/config/ClasspathResourceLoaderTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.config;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClasspathResourceLoaderTest {
+
+    @Test
+    public void testSetProperties() {
+        IResourceLoader classpathLoader = new ClasspathResourceLoader();
+        final IConfig classPathConfig = new ResourceLoaderConfig(classpathLoader);
+        assertEquals("" + BrokerConstants.PORT, classPathConfig.getProperty(BrokerConstants.PORT_PROPERTY_NAME));
+        classPathConfig.setProperty(BrokerConstants.PORT_PROPERTY_NAME, "9999");
+        assertEquals("9999", classPathConfig.getProperty(BrokerConstants.PORT_PROPERTY_NAME));
+    }
+
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/config/ConfigurationParserTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/config/ConfigurationParserTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.config;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.text.ParseException;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ConfigurationParserTest {
+
+    ConfigurationParser m_parser;
+
+    @Before
+    public void setUp() {
+        m_parser = new ConfigurationParser();
+    }
+
+    @Test
+    public void checkDefaultOptions() {
+        Properties props = m_parser.getProperties();
+
+        // verifyDefaults(props);
+        assertTrue(props.isEmpty());
+    }
+
+    @Test
+    public void parseEmpty() throws ParseException {
+        Reader conf = new StringReader("  ");
+        m_parser.parse(conf);
+
+        // Verify
+        // verifyDefaults(m_parser.getProperties());
+        assertTrue(m_parser.getProperties().isEmpty());
+    }
+
+    @Test
+    public void parseValidComment() throws ParseException {
+        Reader conf = new StringReader("#simple comment");
+        m_parser.parse(conf);
+
+        // Verify
+        // verifyDefaults(m_parser.getProperties());
+        assertTrue(m_parser.getProperties().isEmpty());
+    }
+
+    @Test(expected = ParseException.class)
+    public void parseInvalidComment() throws ParseException {
+        Reader conf = new StringReader(" #simple comment");
+        m_parser.parse(conf);
+    }
+
+    @Test
+    public void parseSingleVariable() throws ParseException {
+        Reader conf = new StringReader("port 1234");
+        m_parser.parse(conf);
+
+        // Verify
+        assertEquals("1234", m_parser.getProperties().getProperty("port"));
+    }
+
+    @Test
+    public void parseCompleteFile() throws ParseException {
+        String content = "# This is initial m_config format \r\n" + "  \r\n" + "port 1234 \r\n"
+                + "host   localhost \r\n" + "fake  multi word string property\r\n";
+        Reader conf = new StringReader(content);
+        m_parser.parse(conf);
+
+        // Verify
+        Properties props = m_parser.getProperties();
+        assertEquals("1234", props.getProperty("port"));
+        assertEquals("localhost", props.getProperty("host"));
+        assertEquals("multi word string property", props.getProperty("fake"));
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/security/ACLFileParserTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/security/ACLFileParserTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import org.junit.Test;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.text.ParseException;
+
+import static org.junit.Assert.assertTrue;
+
+public class ACLFileParserTest {
+
+    @Test
+    public void testParseEmpty() throws ParseException {
+        Reader conf = new StringReader("  ");
+        AuthorizationsCollector authorizations = ACLFileParser.parse(conf);
+
+        // Verify
+        assertTrue(authorizations.isEmpty());
+    }
+
+    @Test
+    public void testParseValidComment() throws ParseException {
+        Reader conf = new StringReader("#simple comment");
+        AuthorizationsCollector authorizations = ACLFileParser.parse(conf);
+
+        // Verify
+        assertTrue(authorizations.isEmpty());
+    }
+
+    @Test(expected = ParseException.class)
+    public void testParseInvalidPaddedComment() throws ParseException {
+        Reader conf = new StringReader(" #simple comment");
+        AuthorizationsCollector authorizations = ACLFileParser.parse(conf);
+
+        // Verify
+        assertTrue(authorizations.isEmpty());
+    }
+
+    @Test
+    public void testParseSingleLineACL() throws ParseException {
+        Reader conf = new StringReader("topic /weather/italy/anemometer");
+        AuthorizationsCollector authorizations = ACLFileParser.parse(conf);
+
+        // Verify
+        assertTrue(authorizations.canRead(new Topic("/weather/italy/anemometer"), "", ""));
+        assertTrue(authorizations.canWrite(new Topic("/weather/italy/anemometer"), "", ""));
+    }
+
+    @Test
+    public void testParseValidEndLineComment() throws ParseException {
+        Reader conf = new StringReader("topic /weather/italy/anemometer #simple comment");
+        AuthorizationsCollector authorizations = ACLFileParser.parse(conf);
+
+        // Verify
+        assertTrue(authorizations.canRead(new Topic("/weather/italy/anemometer"), "", ""));
+        assertTrue(authorizations.canWrite(new Topic("/weather/italy/anemometer"), "", ""));
+    }
+
+    @Test
+    public void testParseValidPoundTopicWithEndLineComment() throws ParseException {
+        Reader conf = new StringReader("topic /weather/italy/anemometer/# #simple comment");
+        AuthorizationsCollector authorizations = ACLFileParser.parse(conf);
+
+        // Verify
+        assertTrue(authorizations.canRead(new Topic("/weather/italy/anemometer/#"), "", ""));
+        assertTrue(authorizations.canWrite(new Topic("/weather/italy/anemometer/#"), "", ""));
+    }
+
+    @Test
+    public void testParseValidPlusTopicWithEndLineComment() throws ParseException {
+        Reader conf = new StringReader("topic /weather/+/anemometer #simple comment");
+        AuthorizationsCollector authorizations = ACLFileParser.parse(conf);
+
+        // Verify
+        assertTrue(authorizations.canRead(new Topic("/weather/+/anemometer"), "", ""));
+        assertTrue(authorizations.canWrite(new Topic("/weather/+/anemometer"), "", ""));
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/security/AuthorizationsCollectorTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/security/AuthorizationsCollectorTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.text.ParseException;
+
+import static org.junit.Assert.*;
+
+public class AuthorizationsCollectorTest {
+
+    private static final Authorization RW_ANEMOMETER = new Authorization(new Topic("/weather/italy/anemometer"));
+    private static final Authorization R_ANEMOMETER = new Authorization(
+            new Topic("/weather/italy/anemometer"),
+            Authorization.Permission.READ);
+    private static final Authorization W_ANEMOMETER = new Authorization(
+            new Topic("/weather/italy/anemometer"),
+            Authorization.Permission.WRITE);
+
+    private AuthorizationsCollector authorizator;
+
+    @Before
+    public void setUp() {
+        authorizator = new AuthorizationsCollector();
+    }
+
+    @Test
+    public void testParseAuthLineValid() throws ParseException {
+        Authorization authorization = authorizator.parseAuthLine("topic /weather/italy/anemometer");
+
+        // Verify
+        assertEquals(RW_ANEMOMETER, authorization);
+    }
+
+    @Test
+    public void testParseAuthLineValid_read() throws ParseException {
+        Authorization authorization = authorizator.parseAuthLine("topic read /weather/italy/anemometer");
+
+        // Verify
+        assertEquals(R_ANEMOMETER, authorization);
+    }
+
+    @Test
+    public void testParseAuthLineValid_write() throws ParseException {
+        Authorization authorization = authorizator.parseAuthLine("topic write /weather/italy/anemometer");
+
+        // Verify
+        assertEquals(W_ANEMOMETER, authorization);
+    }
+
+    @Test
+    public void testParseAuthLineValid_readwrite() throws ParseException {
+        Authorization authorization = authorizator.parseAuthLine("topic readwrite /weather/italy/anemometer");
+
+        // Verify
+        assertEquals(RW_ANEMOMETER, authorization);
+    }
+
+    @Test
+    public void testParseAuthLineValid_topic_with_space() throws ParseException {
+        Authorization expected = new Authorization(new Topic("/weather/eastern italy/anemometer"));
+        Authorization authorization = authorizator.parseAuthLine("topic readwrite /weather/eastern italy/anemometer");
+
+        // Verify
+        assertEquals(expected, authorization);
+    }
+
+    @Test(expected = ParseException.class)
+    public void testParseAuthLineValid_invalid() throws ParseException {
+        authorizator.parseAuthLine("topic faker /weather/italy/anemometer");
+    }
+
+    @Test
+    public void testCanWriteSimpleTopic() throws ParseException {
+        authorizator.parse("topic write /sensors");
+
+        // verify
+        assertTrue(authorizator.canWrite(new Topic("/sensors"), "", ""));
+    }
+
+    @Test
+    public void testCanReadSimpleTopic() throws ParseException {
+        authorizator.parse("topic read /sensors");
+
+        // verify
+        assertTrue(authorizator.canRead(new Topic("/sensors"), "", ""));
+    }
+
+    @Test
+    public void testCanReadWriteMixedSimpleTopic() throws ParseException {
+        authorizator.parse("topic write /sensors");
+        authorizator.parse("topic read /sensors/anemometer");
+
+        // verify
+        assertTrue(authorizator.canWrite(new Topic("/sensors"), "", ""));
+        assertFalse(authorizator.canRead(new Topic("/sensors"), "", ""));
+    }
+
+    @Test
+    public void testCanWriteMultiMatherTopic() throws ParseException {
+        authorizator.parse("topic write /sensors/#");
+
+        // verify
+        assertTrue(authorizator.canWrite(new Topic("/sensors/anemometer/wind"), "", ""));
+    }
+
+    @Test
+    public void testCanWriteSingleMatherTopic() throws ParseException {
+        authorizator.parse("topic write /sensors/+");
+
+        // verify
+        assertTrue(authorizator.canWrite(new Topic("/sensors/anemometer"), "", ""));
+    }
+
+    @Test
+    public void testCanWriteUserTopic() throws ParseException {
+        authorizator.parse("user john");
+        authorizator.parse("topic write /sensors");
+
+        // verify
+        assertTrue(authorizator.canWrite(new Topic("/sensors"), "john", ""));
+        assertFalse(authorizator.canWrite(new Topic("/sensors"), "jack", ""));
+    }
+
+    @Test
+    public void testPatternClientLineACL() throws ParseException {
+        authorizator.parse("pattern read /weather/italy/%c");
+
+        // Verify
+        assertTrue(authorizator.canRead(new Topic("/weather/italy/anemometer1"), "", "anemometer1"));
+    }
+
+    @Test
+    public void testPatternClientAndUserLineACL() throws ParseException {
+        authorizator.parse("pattern read /weather/%u/%c");
+
+        // Verify
+        assertTrue(authorizator.canRead(new Topic("/weather/italy/anemometer1"), "italy", "anemometer1"));
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/security/DBAuthenticatorTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/security/DBAuthenticatorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+import org.apache.commons.codec.binary.Hex;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DBAuthenticatorTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DBAuthenticatorTest.class);
+
+    public static final String ORG_H2_DRIVER = "org.h2.Driver";
+    public static final String JDBC_H2_MEM_TEST = "jdbc:h2:mem:test";
+    public static final String SHA_256 = "SHA-256";
+    private Connection connection;
+
+    @Before
+    public void setup() throws ClassNotFoundException, SQLException, NoSuchAlgorithmException {
+        Class.forName(ORG_H2_DRIVER);
+        this.connection = DriverManager.getConnection(JDBC_H2_MEM_TEST);
+        Statement statement = this.connection.createStatement();
+        try {
+            statement.execute("DROP TABLE ACCOUNT");
+        } catch (SQLException sqle) {
+            LOG.info("Table not found, not dropping", sqle);
+        }
+        MessageDigest digest = MessageDigest.getInstance(SHA_256);
+        String hash = new String(Hex.encodeHex(digest.digest("password".getBytes(StandardCharsets.UTF_8))));
+        try {
+            if (statement.execute("CREATE TABLE ACCOUNT ( LOGIN VARCHAR(64), PASSWORD VARCHAR(256))")) {
+                throw new SQLException("can't create USER table");
+            }
+            if (statement.execute("INSERT INTO ACCOUNT ( LOGIN , PASSWORD ) VALUES ('dbuser', '" + hash + "')")) {
+                throw new SQLException("can't insert in USER table");
+            }
+        } catch (SQLException sqle) {
+            LOG.error("Table not created, not inserted", sqle);
+            return;
+        }
+        LOG.info("Table User created");
+        statement.close();
+    }
+
+    @Test
+    public void Db_verifyValid() {
+        final DBAuthenticator dbAuthenticator = new DBAuthenticator(
+                ORG_H2_DRIVER,
+                JDBC_H2_MEM_TEST,
+                "SELECT PASSWORD FROM ACCOUNT WHERE LOGIN=?",
+                SHA_256);
+        assertTrue(dbAuthenticator.checkValid(null, "dbuser", "password".getBytes(UTF_8)));
+    }
+
+    @Test
+    public void Db_verifyInvalidLogin() {
+        final DBAuthenticator dbAuthenticator = new DBAuthenticator(
+                ORG_H2_DRIVER,
+                JDBC_H2_MEM_TEST,
+                "SELECT PASSWORD FROM ACCOUNT WHERE LOGIN=?",
+                SHA_256);
+        assertFalse(dbAuthenticator.checkValid(null, "dbuser2", "password".getBytes(UTF_8)));
+    }
+
+    @Test
+    public void Db_verifyInvalidPassword() {
+        final DBAuthenticator dbAuthenticator = new DBAuthenticator(
+                ORG_H2_DRIVER,
+                JDBC_H2_MEM_TEST,
+                "SELECT PASSWORD FROM ACCOUNT WHERE LOGIN=?",
+                SHA_256);
+        assertFalse(dbAuthenticator.checkValid(null, "dbuser", "wrongPassword".getBytes(UTF_8)));
+    }
+
+    @After
+    public void teardown() {
+        try {
+            this.connection.close();
+        } catch (SQLException e) {
+            LOG.error("can't close connection", e);
+        }
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/security/FileAuthenticatorTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/security/FileAuthenticatorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.broker.security;
+
+import org.junit.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("deprecation")
+public class FileAuthenticatorTest {
+
+    @Test
+    public void loadPasswordFile_verifyValid() {
+        String file = getClass().getResource("/password_file.conf").getPath();
+        IAuthenticator auth = new FileAuthenticator(null, file);
+
+        assertTrue(auth.checkValid(null, "testuser", "passwd".getBytes(UTF_8)));
+    }
+
+    @Test
+    public void loadPasswordFile_verifyInvalid() {
+        String file = getClass().getResource("/password_file.conf").getPath();
+        IAuthenticator auth = new FileAuthenticator(null, file);
+
+        assertFalse(auth.checkValid(null, "testuser2", "passwd".getBytes(UTF_8)));
+    }
+
+    @Test
+    public void loadPasswordFile_verifyDirectoryRef() {
+        IAuthenticator auth = new FileAuthenticator("", "");
+
+        assertFalse(auth.checkValid(null, "testuser2", "passwd".getBytes(UTF_8)));
+    }
+
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/subscriptions/CTrieSubscriptionDirectoryMatchingTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/subscriptions/CTrieSubscriptionDirectoryMatchingTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+
+import com.echostreams.pulsar.mqtt.broker.ISubscriptionsRepository;
+import com.echostreams.pulsar.mqtt.persistence.MemorySubscriptionsRepository;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.echostreams.pulsar.mqtt.broker.subscriptions.Topic.asTopic;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CTrieSubscriptionDirectoryMatchingTest {
+
+    private CTrieSubscriptionDirectory sut;
+    private ISubscriptionsRepository sessionsRepository;
+
+    @Before
+    public void setUp() {
+        sut = new CTrieSubscriptionDirectory();
+
+        this.sessionsRepository = new MemorySubscriptionsRepository();
+        sut.init(this.sessionsRepository);
+    }
+
+    @Test
+    public void testMatchSimple() {
+        Subscription slashSub = CTrieTest.clientSubOnTopic("TempSensor1", "/");
+        sut.add(slashSub);
+        assertThat(sut.matchWithoutQosSharpening(asTopic("finance"))).isEmpty();
+
+        Subscription slashFinanceSub = CTrieTest.clientSubOnTopic("TempSensor1", "/finance");
+        sut.add(slashFinanceSub);
+        assertThat(sut.matchWithoutQosSharpening(asTopic("finance"))).isEmpty();
+
+        assertThat(sut.matchWithoutQosSharpening(asTopic("/finance"))).contains(slashFinanceSub);
+        assertThat(sut.matchWithoutQosSharpening(asTopic("/"))).contains(slashSub);
+    }
+
+    @Test
+    public void testMatchSimpleMulti() {
+        Subscription anySub = CTrieTest.clientSubOnTopic("TempSensor1", "#");
+        sut.add(anySub);
+        assertThat(sut.matchWithoutQosSharpening(asTopic("finance"))).contains(anySub);
+
+        Subscription financeAnySub = CTrieTest.clientSubOnTopic("TempSensor1", "finance/#");
+        sut.add(financeAnySub);
+        assertThat(sut.matchWithoutQosSharpening(asTopic("finance"))).containsExactlyInAnyOrder(financeAnySub, anySub);
+    }
+
+    @Test
+    public void testMatchingDeepMulti_one_layer() {
+        Subscription anySub = CTrieTest.clientSubOnTopic("AllSensor1", "#");
+        Subscription financeAnySub = CTrieTest.clientSubOnTopic("FinanceSensor", "finance/#");
+        sut.add(anySub);
+        sut.add(financeAnySub);
+
+        // Verify
+        assertThat(sut.matchWithoutQosSharpening(asTopic("finance/stock")))
+            .containsExactlyInAnyOrder(financeAnySub, anySub);
+        assertThat(sut.matchWithoutQosSharpening(asTopic("finance/stock/ibm")))
+            .containsExactlyInAnyOrder(financeAnySub, anySub);
+//        System.out.println(sut.dumpTree());
+    }
+
+    @Test
+    public void testMatchingDeepMulti_two_layer() {
+        Subscription financeAnySub = CTrieTest.clientSubOnTopic("FinanceSensor", "finance/stock/#");
+        sut.add(financeAnySub);
+
+        // Verify
+        assertThat(sut.matchWithoutQosSharpening(asTopic("finance/stock/ibm"))).containsExactly(financeAnySub);
+    }
+
+    @Test
+    public void testMatchSimpleSingle() {
+        Subscription anySub = CTrieTest.clientSubOnTopic("AnySensor", "+");
+        sut.add(anySub);
+        assertThat(sut.matchWithoutQosSharpening(asTopic("finance"))).containsExactly(anySub);
+
+        Subscription financeOne = CTrieTest.clientSubOnTopic("AnySensor", "finance/+");
+        sut.add(financeOne);
+        assertThat(sut.matchWithoutQosSharpening(asTopic("finance/stock"))).containsExactly(financeOne);
+    }
+
+    @Test
+    public void testMatchManySingle() {
+        Subscription manySub = CTrieTest.clientSubOnTopic("AnySensor", "+/+");
+        sut.add(manySub);
+
+        // verify
+        assertThat(sut.matchWithoutQosSharpening(asTopic("/finance"))).contains(manySub);
+    }
+
+    @Test
+    public void testMatchSlashSingle() {
+        Subscription slashPlusSub = CTrieTest.clientSubOnTopic("AnySensor", "/+");
+        sut.add(slashPlusSub);
+        Subscription anySub = CTrieTest.clientSubOnTopic("AnySensor", "+");
+        sut.add(anySub);
+
+        // Verify
+        assertThat(sut.matchWithoutQosSharpening(asTopic("/finance"))).containsOnly(slashPlusSub);
+        assertThat(sut.matchWithoutQosSharpening(asTopic("/finance"))).doesNotContain(anySub);
+    }
+
+    @Test
+    public void testMatchManyDeepSingle() {
+        Subscription slashPlusSub = CTrieTest.clientSubOnTopic("FinanceSensor1", "/finance/+/ibm");
+        sut.add(slashPlusSub);
+        Subscription slashPlusDeepSub = CTrieTest.clientSubOnTopic("FinanceSensor2", "/+/stock/+");
+        sut.add(slashPlusDeepSub);
+
+        // Verify
+        assertThat(sut.matchWithoutQosSharpening(asTopic("/finance/stock/ibm")))
+            .containsExactlyInAnyOrder(slashPlusSub, slashPlusDeepSub);
+    }
+
+    @Test
+    public void testMatchSimpleMulti_allTheTree() {
+        Subscription sub = CTrieTest.clientSubOnTopic("AnySensor1", "#");
+        sut.add(sub);
+
+        assertThat(sut.matchWithoutQosSharpening(asTopic("finance"))).isNotEmpty();
+        assertThat(sut.matchWithoutQosSharpening(asTopic("finance/ibm"))).isNotEmpty();
+    }
+
+    @Test
+    public void rogerLightTopicMatches() {
+        assertMatch("foo/bar", "foo/bar");
+        assertMatch("foo/bar", "foo/bar");
+        assertMatch("foo/+", "foo/bar");
+        assertMatch("foo/+/baz", "foo/bar/baz");
+        assertMatch("foo/+/#", "foo/bar/baz");
+        assertMatch("#", "foo/bar/baz");
+
+        assertNotMatch("foo/bar", "foo");
+        assertNotMatch("foo/+", "foo/bar/baz");
+        assertNotMatch("foo/+/baz", "foo/bar/bar");
+        assertNotMatch("foo/+/#", "fo2/bar/baz");
+
+        assertMatch("#", "/foo/bar");
+        assertMatch("/#", "/foo/bar");
+        assertNotMatch("/#", "foo/bar");
+
+        assertMatch("foo//bar", "foo//bar");
+        assertMatch("foo//+", "foo//bar");
+        assertMatch("foo/+/+/baz", "foo///baz");
+        assertMatch("foo/bar/+", "foo/bar/");
+    }
+
+    private void assertMatch(String s, String t) {
+        sut = new CTrieSubscriptionDirectory();
+        ISubscriptionsRepository sessionsRepository = new MemorySubscriptionsRepository();
+        sut.init(sessionsRepository);
+
+        Subscription sub = CTrieTest.clientSubOnTopic("AnySensor1", s);
+        sut.add(sub);
+
+        assertThat(sut.matchWithoutQosSharpening(asTopic(t))).isNotEmpty();
+    }
+
+    private void assertNotMatch(String subscription, String topic) {
+        sut = new CTrieSubscriptionDirectory();
+        ISubscriptionsRepository sessionsRepository = new MemorySubscriptionsRepository();
+        sut.init(sessionsRepository);
+
+        Subscription sub = CTrieTest.clientSubOnTopic("AnySensor1", subscription);
+        sut.add(sub);
+
+        assertThat(sut.matchWithoutQosSharpening(asTopic(topic))).isEmpty();
+    }
+
+    @Test
+    public void testOverlappingSubscriptions() {
+        Subscription genericSub = new Subscription("Sensor1", asTopic("a/+"), MqttQoS.AT_MOST_ONCE);
+        this.sessionsRepository.addNewSubscription(genericSub);
+        sut.add(genericSub);
+
+        Subscription specificSub = new Subscription("Sensor1", asTopic("a/b"), MqttQoS.AT_MOST_ONCE);
+        this.sessionsRepository.addNewSubscription(specificSub);
+        sut.add(specificSub);
+
+        //Exercise
+        final Set<Subscription> matchingForSpecific = sut.matchQosSharpening(asTopic("a/b"));
+
+        // Verify
+        assertThat(matchingForSpecific.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void removeSubscription_withDifferentClients_subscribedSameTopic() {
+        Subscription slashSub = CTrieTest.clientSubOnTopic("Sensor1", "/topic");
+        sut.add(slashSub);
+        Subscription slashSub2 = CTrieTest.clientSubOnTopic("Sensor2", "/topic");
+        sut.add(slashSub2);
+
+        // Exercise
+        sut.removeSubscription(asTopic("/topic"), slashSub2.clientId);
+
+        // Verify
+        Subscription remainedSubscription = sut.matchWithoutQosSharpening(asTopic("/topic")).iterator().next();
+        assertThat(remainedSubscription.clientId).isEqualTo(slashSub.clientId);
+        assertEquals(slashSub.clientId, remainedSubscription.clientId);
+    }
+
+    @Test
+    public void removeSubscription_sameClients_subscribedSameTopic() {
+        Subscription slashSub = CTrieTest.clientSubOnTopic("Sensor1", "/topic");
+        sut.add(slashSub);
+
+        // Exercise
+        sut.removeSubscription(asTopic("/topic"), slashSub.clientId);
+
+        // Verify
+        final Set<Subscription> matchingSubscriptions = sut.matchWithoutQosSharpening(asTopic("/topic"));
+        assertThat(matchingSubscriptions).isEmpty();
+    }
+
+    /*
+     * Test for Issue #49
+     */
+    @Test
+    public void duplicatedSubscriptionsWithDifferentQos() {
+        Subscription client2Sub = new Subscription("client2", asTopic("client/test/b"), MqttQoS.AT_MOST_ONCE);
+        this.sut.add(client2Sub);
+        Subscription client1SubQoS0 = new Subscription("client1", asTopic("client/test/b"), MqttQoS.AT_MOST_ONCE);
+        this.sut.add(client1SubQoS0);
+
+        Subscription client1SubQoS2 = new Subscription("client1", asTopic("client/test/b"), MqttQoS.EXACTLY_ONCE);
+        this.sut.add(client1SubQoS2);
+
+        // Verify
+        Set<Subscription> subscriptions = this.sut.matchQosSharpening(asTopic("client/test/b"));
+        assertThat(subscriptions).contains(client1SubQoS2);
+        assertThat(subscriptions).contains(client2Sub);
+
+        final Optional<Subscription> matchingClient1Sub = subscriptions
+            .stream()
+            .filter(s -> s.equals(client1SubQoS0))
+            .findFirst();
+        assertTrue(matchingClient1Sub.isPresent());
+        Subscription client1Sub = matchingClient1Sub.get();
+
+        assertThat(client1SubQoS0.getRequestedQos()).isNotEqualTo(client1Sub.getRequestedQos());
+
+        // client1SubQoS2 should override client1SubQoS0
+        assertThat(client1Sub.getRequestedQos()).isEqualTo(client1SubQoS2.getRequestedQos());
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/subscriptions/CTrieTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/subscriptions/CTrieTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+
+import io.netty.handler.codec.mqtt.MqttQoS;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.echostreams.pulsar.mqtt.broker.subscriptions.Topic.asTopic;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CTrieTest {
+
+    private CTrie sut;
+
+    @Before
+    public void setUp() {
+        sut = new CTrie();
+    }
+
+    @Test
+    public void testAddOnSecondLayerWithEmptyTokenOnEmptyTree() {
+        //Exercise
+        sut.addToTree(clientSubOnTopic("TempSensor1", "/"));
+
+        //Verify
+        final Optional<CNode> matchedNode = sut.lookup(asTopic("/"));
+        assertTrue("Node on path / must be present", matchedNode.isPresent());
+        //verify structure, only root INode and the first CNode should be present
+        assertThat(this.sut.root.mainNode().subscriptions).isEmpty();
+        assertThat(this.sut.root.mainNode().allChildren()).isNotEmpty();
+
+        INode firstLayer = this.sut.root.mainNode().allChildren().get(0);
+        assertThat(firstLayer.mainNode().subscriptions).isEmpty();
+        assertThat(firstLayer.mainNode().allChildren()).isNotEmpty();
+
+        INode secondLayer = firstLayer.mainNode().allChildren().get(0);
+        assertThat(secondLayer.mainNode().subscriptions).isNotEmpty();
+        assertThat(secondLayer.mainNode().allChildren()).isEmpty();
+    }
+
+    @Test
+    public void testAddFirstLayerNodeOnEmptyTree() {
+        //Exercise
+        sut.addToTree(clientSubOnTopic("TempSensor1", "/temp"));
+
+        //Verify
+        final Optional<CNode> matchedNode = sut.lookup(asTopic("/temp"));
+        assertTrue("Node on path /temp must be present", matchedNode.isPresent());
+        assertFalse(matchedNode.get().subscriptions.isEmpty());
+    }
+
+    @Test
+    public void testLookup() {
+        final Subscription existingSubscription = clientSubOnTopic("TempSensor1", "/temp");
+        sut.addToTree(existingSubscription);
+
+        //Exercise
+        final Optional<CNode> matchedNode = sut.lookup(asTopic("/humidity"));
+
+        //Verify
+        assertFalse("Node on path /humidity can't be present", matchedNode.isPresent());
+    }
+
+    @Test
+    public void testAddNewSubscriptionOnExistingNode() {
+        final Subscription existingSubscription = clientSubOnTopic("TempSensor1", "/temp");
+        sut.addToTree(existingSubscription);
+
+        //Exercise
+        final Subscription newSubscription = clientSubOnTopic("TempSensor2", "/temp");
+        sut.addToTree(newSubscription);
+
+        //Verify
+        final Optional<CNode> matchedNode = sut.lookup(asTopic("/temp"));
+        assertTrue("Node on path /temp must be present", matchedNode.isPresent());
+        final Set<Subscription> subscriptions = matchedNode.get().subscriptions;
+        assertTrue(subscriptions.contains(newSubscription));
+    }
+
+    @Test
+    public void testAddNewDeepNodes() {
+        sut.addToTree(clientSubOnTopic("TempSensorRM", "/italy/roma/temp"));
+        sut.addToTree(clientSubOnTopic("TempSensorFI", "/italy/firenze/temp"));
+        sut.addToTree(clientSubOnTopic("HumSensorFI", "/italy/roma/humidity"));
+        final Subscription happinessSensor = clientSubOnTopic("HappinessSensor", "/italy/happiness");
+        sut.addToTree(happinessSensor);
+
+        //Verify
+        final Optional<CNode> matchedNode = sut.lookup(asTopic("/italy/happiness"));
+        assertTrue("Node on path /italy/happiness must be present", matchedNode.isPresent());
+        final Set<Subscription> subscriptions = matchedNode.get().subscriptions;
+        assertTrue(subscriptions.contains(happinessSensor));
+    }
+
+    static Subscription clientSubOnTopic(String clientID, String topicName) {
+        return new Subscription(clientID, asTopic(topicName), null);
+    }
+
+    @Test
+    public void givenTreeWithSomeNodeWhenRemoveContainedSubscriptionThenNodeIsUpdated() {
+        sut.addToTree(clientSubOnTopic("TempSensor1", "/temp"));
+
+        //Exercise
+        sut.removeFromTree(asTopic("/temp"), "TempSensor1");
+
+        //Verify
+        final Optional<CNode> matchedNode = sut.lookup(asTopic("/temp"));
+        assertFalse("Node on path /temp can't be present", matchedNode.isPresent());
+    }
+
+    @Test
+    public void givenTreeWithSomeNodeUnsubscribeAndResubscribeCleanTomb() {
+        sut.addToTree(clientSubOnTopic("TempSensor1", "test"));
+        sut.removeFromTree(asTopic("test"), "TempSensor1");
+
+        sut.addToTree(clientSubOnTopic("TempSensor1", "test"));
+        assertTrue(sut.root.mainNode().allChildren().size() == 1);  // looking to see if TNode is cleaned up
+    }
+
+    @Test
+    public void givenTreeWithSomeNodeWhenRemoveMultipleTimes() {
+        sut.addToTree(clientSubOnTopic("TempSensor1", "test"));
+
+        // make sure no TNode exceptions
+        sut.removeFromTree(asTopic("test"), "TempSensor1");
+        sut.removeFromTree(asTopic("test"), "TempSensor1");
+        sut.removeFromTree(asTopic("test"), "TempSensor1");
+        sut.removeFromTree(asTopic("test"), "TempSensor1");
+
+        //Verify
+        final Optional<CNode> matchedNode = sut.lookup(asTopic("/temp"));
+        assertFalse("Node on path /temp can't be present", matchedNode.isPresent());
+    }
+
+    @Test
+    public void givenTreeWithSomeDeepNodeWhenRemoveMultipleTimes() {
+        sut.addToTree(clientSubOnTopic("TempSensor1", "/test/me/1/2/3"));
+
+        // make sure no TNode exceptions
+        sut.removeFromTree(asTopic("/test/me/1/2/3"), "TempSensor1");
+        sut.removeFromTree(asTopic("/test/me/1/2/3"), "TempSensor1");
+        sut.removeFromTree(asTopic("/test/me/1/2/3"), "TempSensor1");
+
+        //Verify
+        final Optional<CNode> matchedNode = sut.lookup(asTopic("/temp"));
+        assertFalse("Node on path /temp can't be present", matchedNode.isPresent());
+    }
+
+    @Test
+    public void givenTreeWithSomeNodeHierarchWhenRemoveContainedSubscriptionThenNodeIsUpdated() {
+        sut.addToTree(clientSubOnTopic("TempSensor1", "/temp/1"));
+        sut.addToTree(clientSubOnTopic("TempSensor1", "/temp/2"));
+
+        //Exercise
+        sut.removeFromTree(asTopic("/temp/1"), "TempSensor1");
+
+        sut.removeFromTree(asTopic("/temp/1"), "TempSensor1");
+        final Set<Subscription> matchingSubs = sut.recursiveMatch(asTopic("/temp/2"));
+
+        //Verify
+        final Subscription expectedMatchingsub = new Subscription("TempSensor1", asTopic("/temp/2"), MqttQoS.AT_MOST_ONCE);
+        assertThat(matchingSubs).contains(expectedMatchingsub);
+    }
+
+    @Test
+    public void givenTreeWithSomeNodeHierarchWhenRemoveContainedSubscriptionSmallerThenNodeIsNotUpdated() {
+        sut.addToTree(clientSubOnTopic("TempSensor1", "/temp/1"));
+        sut.addToTree(clientSubOnTopic("TempSensor1", "/temp/2"));
+
+        //Exercise
+        sut.removeFromTree(asTopic("/temp"), "TempSensor1");
+
+        final Set<Subscription> matchingSubs1 = sut.recursiveMatch(asTopic("/temp/1"));
+        final Set<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("/temp/2"));
+
+        //Verify
+        // not clear to me, but I believe /temp unsubscribe should not unsub you from downstream /temp/1 or /temp/2
+        final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("/temp/1"), MqttQoS.AT_MOST_ONCE);
+        assertThat(matchingSubs1).contains(expectedMatchingsub1);
+        final Subscription expectedMatchingsub2 = new Subscription("TempSensor1", asTopic("/temp/2"), MqttQoS.AT_MOST_ONCE);
+        assertThat(matchingSubs2).contains(expectedMatchingsub2);
+    }
+
+    @Test
+    public void givenTreeWithDeepNodeWhenRemoveContainedSubscriptionThenNodeIsUpdated() {
+        sut.addToTree(clientSubOnTopic("TempSensor1", "/bah/bin/bash"));
+
+        sut.removeFromTree(asTopic("/bah/bin/bash"), "TempSensor1");
+
+        //Verify
+        final Optional<CNode> matchedNode = sut.lookup(asTopic("/bah/bin/bash"));
+        assertFalse("Node on path /temp can't be present", matchedNode.isPresent());
+    }
+
+    @Test
+    public void testMatchSubscriptionNoWildcards() {
+        sut.addToTree(clientSubOnTopic("TempSensor1", "/temp"));
+
+        //Exercise
+        final Set<Subscription> matchingSubs = sut.recursiveMatch(asTopic("/temp"));
+
+        //Verify
+        final Subscription expectedMatchingsub = new Subscription("TempSensor1", asTopic("/temp"), MqttQoS.AT_MOST_ONCE);
+        assertThat(matchingSubs).contains(expectedMatchingsub);
+    }
+
+    @Test
+    public void testRemovalInnerTopicOffRootSameClient() {
+        sut.addToTree(clientSubOnTopic("TempSensor1", "temp"));
+        sut.addToTree(clientSubOnTopic("TempSensor1", "temp/1"));
+
+        //Exercise
+        final Set<Subscription> matchingSubs1 = sut.recursiveMatch(asTopic("temp"));
+        final Set<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("temp/1"));
+
+        //Verify
+        final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("temp"), MqttQoS.AT_MOST_ONCE);
+        final Subscription expectedMatchingsub2 = new Subscription("TempSensor1", asTopic("temp/1"), MqttQoS.AT_MOST_ONCE);
+
+        assertThat(matchingSubs1).contains(expectedMatchingsub1);
+        assertThat(matchingSubs2).contains(expectedMatchingsub2);
+
+        sut.removeFromTree(asTopic("temp"), "TempSensor1");
+
+        //Exercise
+        final Set<Subscription> matchingSubs3 = sut.recursiveMatch(asTopic("temp"));
+        final Set<Subscription> matchingSubs4 = sut.recursiveMatch(asTopic("temp/1"));
+
+        assertThat(matchingSubs3).doesNotContain(expectedMatchingsub1);
+        assertThat(matchingSubs4).contains(expectedMatchingsub2);
+    }
+
+    @Test
+    public void testRemovalInnerTopicOffRootDiffClient() {
+        sut.addToTree(clientSubOnTopic("TempSensor1", "temp"));
+        sut.addToTree(clientSubOnTopic("TempSensor2", "temp/1"));
+
+        //Exercise
+        final Set<Subscription> matchingSubs1 = sut.recursiveMatch(asTopic("temp"));
+        final Set<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("temp/1"));
+
+        //Verify
+        final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("temp"), MqttQoS.AT_MOST_ONCE);
+        final Subscription expectedMatchingsub2 = new Subscription("TempSensor2", asTopic("temp/1"), MqttQoS.AT_MOST_ONCE);
+
+        assertThat(matchingSubs1).contains(expectedMatchingsub1);
+        assertThat(matchingSubs2).contains(expectedMatchingsub2);
+
+        sut.removeFromTree(asTopic("temp"), "TempSensor1");
+
+        //Exercise
+        final Set<Subscription> matchingSubs3 = sut.recursiveMatch(asTopic("temp"));
+        final Set<Subscription> matchingSubs4 = sut.recursiveMatch(asTopic("temp/1"));
+
+        assertThat(matchingSubs3).doesNotContain(expectedMatchingsub1);
+        assertThat(matchingSubs4).contains(expectedMatchingsub2);
+    }
+
+    @Test
+    public void testRemovalOuterTopicOffRootDiffClient() {
+        sut.addToTree(clientSubOnTopic("TempSensor1", "temp"));
+        sut.addToTree(clientSubOnTopic("TempSensor2", "temp/1"));
+
+        //Exercise
+        final Set<Subscription> matchingSubs1 = sut.recursiveMatch(asTopic("temp"));
+        final Set<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("temp/1"));
+
+        //Verify
+        final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("temp"), MqttQoS.AT_MOST_ONCE);
+        final Subscription expectedMatchingsub2 = new Subscription("TempSensor2", asTopic("temp/1"), MqttQoS.AT_MOST_ONCE);
+
+        assertThat(matchingSubs1).contains(expectedMatchingsub1);
+        assertThat(matchingSubs2).contains(expectedMatchingsub2);
+
+        sut.removeFromTree(asTopic("temp/1"), "TempSensor2");
+
+        //Exercise
+        final Set<Subscription> matchingSubs3 = sut.recursiveMatch(asTopic("temp"));
+        final Set<Subscription> matchingSubs4 = sut.recursiveMatch(asTopic("temp/1"));
+
+        assertThat(matchingSubs3).contains(expectedMatchingsub1);
+        assertThat(matchingSubs4).doesNotContain(expectedMatchingsub2);
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/broker/subscriptions/TopicTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/broker/subscriptions/TopicTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.broker.subscriptions;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TopicTest {
+
+    @Test
+    public void testParseTopic() {
+        assertThat(new Topic("finance/stock/ibm")).containsToken("finance", "stock", "ibm");
+
+        assertThat(new Topic("/finance/stock/ibm")).containsToken(Token.EMPTY, "finance", "stock", "ibm");
+
+        assertThat(new Topic("/")).containsToken(Token.EMPTY, Token.EMPTY);
+    }
+
+    @Test
+    public void testParseTopicMultiValid() {
+        assertThat(new Topic("finance/stock/#")).containsToken("finance", "stock", Token.MULTI);
+
+        assertThat(new Topic("#")).containsToken(Token.MULTI);
+    }
+
+    @Test
+    public void testValidationProcess() {
+        // TopicMultiInTheMiddle
+        assertThat(new Topic("finance/#/closingprice")).isInValid();
+
+        // MultiNotAfterSeparator
+        assertThat(new Topic("finance#")).isInValid();
+
+        // TopicMultiNotAlone
+        assertThat(new Topic("/finance/#closingprice")).isInValid();
+
+        // SingleNotAferSeparator
+        assertThat(new Topic("finance+")).isInValid();
+
+        assertThat(new Topic("finance/+")).isValid();
+    }
+
+    @Test
+    public void testParseTopicSingleValid() {
+        assertThat(new Topic("finance/stock/+")).containsToken("finance", "stock", Token.SINGLE);
+
+        assertThat(new Topic("+")).containsToken(Token.SINGLE);
+
+        assertThat(new Topic("finance/+/ibm")).containsToken("finance", Token.SINGLE, "ibm");
+    }
+
+    @Test
+    public void testMatchTopics_simple() {
+        assertThat(new Topic("/")).matches("/");
+        assertThat(new Topic("/finance")).matches("/finance");
+    }
+
+    @Test
+    public void testMatchTopics_multi() {
+        assertThat(new Topic("finance")).matches("#");
+        assertThat(new Topic("finance")).matches("finance/#");
+        assertThat(new Topic("finance/stock")).matches("finance/#");
+        assertThat(new Topic("finance/stock/ibm")).matches("finance/#");
+    }
+
+    @Test
+    public void testMatchTopics_single() {
+        assertThat(new Topic("finance")).matches("+");
+        assertThat(new Topic("finance/stock")).matches("finance/+");
+        assertThat(new Topic("finance")).doesNotMatch("finance/+");
+        assertThat(new Topic("/finance")).matches("/+");
+        assertThat(new Topic("/finance")).doesNotMatch("+");
+        assertThat(new Topic("/finance")).matches("+/+");
+        assertThat(new Topic("/finance/stock/ibm")).matches("/finance/+/ibm");
+        assertThat(new Topic("/")).matches("+/+");
+        assertThat(new Topic("sport/")).matches("sport/+");
+        assertThat(new Topic("/finance/stock")).doesNotMatch("+");
+    }
+
+    @Test
+    public void rogerLightMatchTopics() {
+        assertThat(new Topic("foo/bar")).matches("foo/bar");
+        assertThat(new Topic("foo/bar")).matches("foo/+");
+        assertThat(new Topic("foo/bar/baz")).matches("foo/+/baz");
+        assertThat(new Topic("foo/bar/baz")).matches("foo/+/#");
+        assertThat(new Topic("foo/bar/baz")).matches("#");
+
+        assertThat(new Topic("foo")).doesNotMatch("foo/bar");
+        assertThat(new Topic("foo/bar/baz")).doesNotMatch("foo/+");
+        assertThat(new Topic("foo/bar/bar")).doesNotMatch("foo/+/baz");
+        assertThat(new Topic("fo2/bar/baz")).doesNotMatch("foo/+/#");
+
+        assertThat(new Topic("/foo/bar")).matches("#");
+        assertThat(new Topic("/foo/bar")).matches("/#");
+        assertThat(new Topic("foo/bar")).doesNotMatch("/#");
+
+        assertThat(new Topic("foo//bar")).matches("foo//bar");
+        assertThat(new Topic("foo//bar")).matches("foo//+");
+        assertThat(new Topic("foo///baz")).matches("foo/+/+/baz");
+        assertThat(new Topic("foo/bar/")).matches("foo/bar/+");
+    }
+
+    @Test
+    public void exceptHeadToken() {
+        assertEquals(Topic.asTopic("token"), Topic.asTopic("/token").exceptHeadToken());
+        assertEquals(Topic.asTopic("a/b"), Topic.asTopic("/a/b").exceptHeadToken());
+    }
+
+    public static TopicAssert assertThat(Topic topic) {
+        return new TopicAssert(topic);
+    }
+
+    static class TopicAssert extends AbstractAssert<TopicAssert, Topic> {
+
+        TopicAssert(Topic actual) {
+            super(actual, TopicAssert.class);
+        }
+
+        public TopicAssert matches(String topic) {
+            Assertions.assertThat(actual.match(new Topic(topic))).isTrue();
+
+            return myself;
+        }
+
+        public TopicAssert doesNotMatch(String topic) {
+            Assertions.assertThat(actual.match(new Topic(topic))).isFalse();
+
+            return myself;
+        }
+
+        public TopicAssert containsToken(Object... tokens) {
+            Assertions.assertThat(actual.getTokens()).containsExactly(asArray(tokens));
+
+            return myself;
+        }
+
+        private Token[] asArray(Object... l) {
+            Token[] tokens = new Token[l.length];
+            for (int i = 0; i < l.length; i++) {
+                Object o = l[i];
+                if (o instanceof Token) {
+                    tokens[i] = (Token) o;
+                } else {
+                    tokens[i] = new Token(o.toString());
+                }
+            }
+
+            return tokens;
+        }
+
+        public TopicAssert isValid() {
+            Assertions.assertThat(actual.isValid()).isTrue();
+
+            return myself;
+        }
+
+        public TopicAssert isInValid() {
+            Assertions.assertThat(actual.isValid()).isFalse();
+
+            return myself;
+        }
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/ConfigurationClassLoaderTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/ConfigurationClassLoaderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.Server;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import com.echostreams.pulsar.mqtt.broker.config.MemoryConfig;
+import com.echostreams.pulsar.mqtt.broker.security.IAuthenticator;
+import com.echostreams.pulsar.mqtt.broker.security.IAuthorizatorPolicy;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.Assert.assertTrue;
+
+public class ConfigurationClassLoaderTest implements IAuthenticator, IAuthorizatorPolicy {
+
+    Server m_server;
+    IConfig m_config;
+
+    protected void startServer(Properties props) throws IOException {
+        m_server = new Server();
+        m_config = new MemoryConfig(props);
+        m_server.startServer(m_config);
+    }
+
+    @After
+    public void tearDown() {
+        m_server.stopServer();
+    }
+
+    @Test
+    public void loadAuthenticator() throws Exception {
+        Properties props = new Properties(IntegrationUtils.prepareTestProperties());
+        props.setProperty(BrokerConstants.AUTHENTICATOR_CLASS_NAME, getClass().getName());
+        startServer(props);
+        assertTrue(true);
+    }
+
+    @Test
+    public void loadAuthorizator() throws Exception {
+        Properties props = new Properties(IntegrationUtils.prepareTestProperties());
+        props.setProperty(BrokerConstants.AUTHORIZATOR_CLASS_NAME, getClass().getName());
+        startServer(props);
+        assertTrue(true);
+    }
+
+    @Override
+    public boolean checkValid(String clientID, String username, byte[] password) {
+        return true;
+    }
+
+    @Override
+    public boolean canWrite(Topic topic, String user, String client) {
+        return true;
+    }
+
+    @Override
+    public boolean canRead(Topic topic, String user, String client) {
+        return true;
+    }
+
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/IntegrationUtils.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/IntegrationUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import java.io.File;
+import java.util.Properties;
+
+import static com.echostreams.pulsar.mqtt.BrokerConstants.*;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Used to carry integration configurations.
+ */
+public final class IntegrationUtils {
+
+    static String localH2MvStoreDBPath() {
+        String currentDir = System.getProperty("user.dir");
+        return currentDir + File.separator + "build" + File.separator + DEFAULT_MOQUETTE_STORE_H2_DB_FILENAME;
+    }
+
+    public static Properties prepareTestProperties() {
+        Properties testProperties = new Properties();
+        testProperties.put(PERSISTENT_STORE_PROPERTY_NAME, IntegrationUtils.localH2MvStoreDBPath());
+        testProperties.put(PORT_PROPERTY_NAME, "1883");
+        return testProperties;
+    }
+
+    private IntegrationUtils() {
+    }
+
+    public static void clearTestStorage() {
+        String dbPath = localH2MvStoreDBPath();
+        File dbFile = new File(dbPath);
+        if (dbFile.exists()) {
+            dbFile.delete();
+        }
+        assertFalse(dbFile.exists());
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/MQTTWebSocket.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/MQTTWebSocket.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.StatusCode;
+import org.eclipse.jetty.websocket.api.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@WebSocket
+public class MQTTWebSocket {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MQTTWebSocket.class);
+
+    private final CountDownLatch connectSentLatch;
+
+    public MQTTWebSocket() {
+        this.connectSentLatch = new CountDownLatch(1);
+    }
+
+    @OnWebSocketClose
+    public void onClose(int statusCode, String reason) {
+        System.out.printf("Connection closed: %d - %s%n", statusCode, reason);
+    }
+
+    @OnWebSocketConnect
+    public void onConnect(Session session) throws IOException {
+        System.out.printf("Got connect: %s%n", session);
+        LOG.info("Got connect: %s%n", session);
+
+        // Trivial MQTT Connect message
+        // assertEquals(12, out.readByte()); //remaining length
+        // verifyString("MQIsdp", out);
+        // assertEquals(0x03, out.readByte()); //protocol version
+        // assertEquals(0x32, out.readByte()); //flags
+        // assertEquals(2, out.readByte()); //keepAliveTimer msb
+        // assertEquals(0, out.readByte()); //keepAliveTimer lsb
+
+        ByteBuffer msg = ByteBuffer.wrap(new byte[]{0x10, // message type
+                0x0C, // remaining lenght 12 bytes
+                'M', 'Q', 'I', 's', 'd', 'p', 0x03, // protocol version
+                0x32, // flags
+                0x02, 0x00// keepAlive Timer, 2 seconds
+        });
+        // try {
+        session.getRemote().sendBytes(msg);
+        this.connectSentLatch.countDown();
+        session.close(StatusCode.NORMAL, "I'm done");
+        // } catch (IOException t) {
+        // LOG.error(null, t);
+        // }
+    }
+
+    public boolean awaitConnected(int duration, TimeUnit unit) throws InterruptedException {
+        return this.connectSentLatch.await(duration, unit);
+    }
+
+    @OnWebSocketMessage
+    public void onMessage(Session session, byte[] buf, int offset, int length) {
+        System.out.printf("Got msg: %s%n", buf);
+    }
+
+    @OnWebSocketError
+    public void onError(Session session, Throwable cause) {
+        System.out.printf("Got exception: %s%n", cause);
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/MessageCollector.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/MessageCollector.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2012-2016 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Used in test to collect all messages received asynchronously by MqttClient.
+ */
+public class MessageCollector implements MqttCallback {
+
+    private static final class ReceivedMessage {
+
+        private final MqttMessage message;
+        private final String topic;
+
+        private ReceivedMessage(MqttMessage message, String topic) {
+            this.message = message;
+            this.topic = topic;
+        }
+    }
+
+    private BlockingQueue<ReceivedMessage> m_messages = new LinkedBlockingQueue<>();
+    private boolean m_connectionLost;
+
+    /**
+     * Return the message from the queue if not empty, else return null with wait period.
+     */
+    public MqttMessage getMessageImmediate() {
+        if (m_messages.isEmpty()) {
+            return null;
+        }
+        try {
+            return m_messages.take().message;
+        } catch (InterruptedException e) {
+            return null;
+        }
+    }
+
+    public MqttMessage waitMessage(int delay) {
+        try {
+            ReceivedMessage msg = m_messages.poll(delay, TimeUnit.SECONDS);
+            if (msg == null) {
+                return null;
+            }
+            return msg.message;
+        } catch (InterruptedException e) {
+            return null;
+        }
+    }
+
+    public String getTopic() {
+        try {
+            return m_messages.poll(5, TimeUnit.SECONDS).topic;
+        } catch (InterruptedException e) {
+            return null;
+        }
+    }
+
+    void reinit() {
+        m_messages = new LinkedBlockingQueue<>();
+        m_connectionLost = false;
+    }
+
+    public boolean connectionLost() {
+        return m_connectionLost;
+    }
+
+    @Override
+    public void connectionLost(Throwable cause) {
+        m_connectionLost = true;
+    }
+
+    @Override
+    public void messageArrived(String topic, MqttMessage message) {
+        m_messages.offer(new ReceivedMessage(message, topic));
+    }
+
+    /**
+     * Invoked when the message sent to a integration is ACKED (PUBACK or PUBCOMP by the integration)
+     */
+    @Override
+    public void deliveryComplete(IMqttDeliveryToken token) {
+//        try {
+//            token.waitForCompletion(1_000);
+//            m_messages.offer(new ReceivedMessage(token.getMessage(), token.getTopics()[0]));
+//        } catch (MqttException e) {
+//            e.printStackTrace();
+//        }
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationDBAuthenticatorTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationDBAuthenticatorTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.Server;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import com.echostreams.pulsar.mqtt.broker.config.MemoryConfig;
+import com.echostreams.pulsar.mqtt.broker.security.DBAuthenticator;
+import com.echostreams.pulsar.mqtt.broker.security.DBAuthenticatorTest;
+import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
+import org.junit.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static org.junit.Assert.assertTrue;
+
+public class ServerIntegrationDBAuthenticatorTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIntegrationDBAuthenticatorTest.class);
+
+    static MqttClientPersistence s_dataStore;
+    static MqttClientPersistence s_pubDataStore;
+    static DBAuthenticatorTest dbAuthenticatorTest;
+
+    Server m_server;
+    IMqttClient m_client;
+    IMqttClient m_publisher;
+    MessageCollector m_messagesCollector;
+    IConfig m_config;
+
+    @BeforeClass
+    public static void beforeTests() throws NoSuchAlgorithmException, SQLException, ClassNotFoundException {
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        s_dataStore = new MqttDefaultFilePersistence(tmpDir);
+        s_pubDataStore = new MqttDefaultFilePersistence(tmpDir + File.separator + "publisher");
+        dbAuthenticatorTest = new DBAuthenticatorTest();
+        dbAuthenticatorTest.setup();
+    }
+
+    protected void startServer() throws IOException {
+        m_server = new Server();
+        final Properties configProps = addDBAuthenticatorConf(IntegrationUtils.prepareTestProperties());
+        m_config = new MemoryConfig(configProps);
+        m_server.startServer(m_config);
+    }
+
+    private void stopServer() {
+        m_server.stopServer();
+    }
+
+    private Properties addDBAuthenticatorConf(Properties properties) {
+        properties.put(BrokerConstants.AUTHENTICATOR_CLASS_NAME, DBAuthenticator.class.getCanonicalName());
+        properties.put(BrokerConstants.DB_AUTHENTICATOR_DRIVER, DBAuthenticatorTest.ORG_H2_DRIVER);
+        properties.put(BrokerConstants.DB_AUTHENTICATOR_URL, DBAuthenticatorTest.JDBC_H2_MEM_TEST);
+        properties.put(BrokerConstants.DB_AUTHENTICATOR_QUERY, "SELECT PASSWORD FROM ACCOUNT WHERE LOGIN=?");
+        properties.put(BrokerConstants.DB_AUTHENTICATOR_DIGEST, DBAuthenticatorTest.SHA_256);
+        return properties;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        startServer();
+
+        m_client = new MqttClient("tcp://localhost:1883", "TestClient", s_dataStore);
+        m_messagesCollector = new MessageCollector();
+        m_client.setCallback(m_messagesCollector);
+
+        m_publisher = new MqttClient("tcp://localhost:1883", "Publisher", s_pubDataStore);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (m_client != null && m_client.isConnected()) {
+            m_client.disconnect();
+        }
+
+        if (m_publisher != null && m_publisher.isConnected()) {
+            m_publisher.disconnect();
+        }
+
+        stopServer();
+
+        IntegrationUtils.clearTestStorage();
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        dbAuthenticatorTest.teardown();
+    }
+
+    @Test
+    public void connectWithValidCredentials() throws Exception {
+        LOG.info("*** connectWithCredentials ***");
+        m_client = new MqttClient("tcp://localhost:1883", "Publisher", s_pubDataStore);
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setUserName("dbuser");
+        options.setPassword("password".toCharArray());
+        m_client.connect(options);
+        assertTrue(true);
+    }
+
+    @Test
+    public void connectWithWrongCredentials() {
+        LOG.info("*** connectWithWrongCredentials ***");
+        try {
+            m_client = new MqttClient("tcp://localhost:1883", "Publisher", s_pubDataStore);
+            MqttConnectOptions options = new MqttConnectOptions();
+            options.setUserName("dbuser");
+            options.setPassword("wrongPassword".toCharArray());
+            m_client.connect(options);
+        } catch (MqttException e) {
+            if (e instanceof MqttSecurityException) {
+                assertTrue(true);
+                return;
+            } else {
+                assertTrue(e.getMessage(), false);
+                return;
+            }
+        }
+        assertTrue("must not be connected. cause : wrong password given to client", false);
+    }
+
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationFuseTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationFuseTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import com.echostreams.pulsar.mqtt.broker.Server;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import com.echostreams.pulsar.mqtt.broker.config.MemoryConfig;
+import org.fusesource.mqtt.client.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ServerIntegrationFuseTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIntegrationPahoTest.class);
+
+    Server m_server;
+    MQTT m_mqtt;
+    BlockingConnection m_subscriber;
+    BlockingConnection m_publisher;
+    IConfig m_config;
+
+    protected void startServer() throws IOException {
+        m_server = new Server();
+        final Properties configProps = IntegrationUtils.prepareTestProperties();
+        m_config = new MemoryConfig(configProps);
+        m_server.startServer(m_config);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        startServer();
+
+        m_mqtt = new MQTT();
+        m_mqtt.setHost("localhost", 1883);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (m_subscriber != null) {
+            m_subscriber.disconnect();
+        }
+
+        if (m_publisher != null) {
+            m_publisher.disconnect();
+        }
+
+        m_server.stopServer();
+
+        IntegrationUtils.clearTestStorage();
+    }
+
+    @Test
+    public void checkWillTestamentIsPublishedOnConnectionKill_noRetain() throws Exception {
+        LOG.info("checkWillTestamentIsPublishedOnConnectionKill_noRetain");
+
+        String willTestamentTopic = "/will/test";
+        String willTestamentMsg = "Bye bye";
+
+        MQTT mqtt = new MQTT();
+        mqtt.setHost("localhost", 1883);
+        mqtt.setClientId("WillTestamentPublisher");
+        mqtt.setWillRetain(false);
+        mqtt.setWillMessage(willTestamentMsg);
+        mqtt.setWillTopic(willTestamentTopic);
+        m_publisher = mqtt.blockingConnection();
+        m_publisher.connect();
+
+        m_mqtt.setHost("localhost", 1883);
+        m_mqtt.setCleanSession(false);
+        m_mqtt.setClientId("Subscriber");
+        m_subscriber = m_mqtt.blockingConnection();
+        m_subscriber.connect();
+        Topic[] topics = new Topic[]{new Topic(willTestamentTopic, QoS.AT_MOST_ONCE)};
+        m_subscriber.subscribe(topics);
+
+        // Exercise, kill the publisher connection
+        m_publisher.kill();
+
+        // Verify, that the testament is fired
+        Message msg = m_subscriber.receive(1, TimeUnit.SECONDS); // wait the flush interval (1 sec)
+        assertNotNull("We should get notified with 'Will' message", msg);
+        msg.ack();
+        assertEquals(willTestamentMsg, new String(msg.getPayload(), UTF_8));
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationOpenSSLTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationOpenSSLTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.Server;
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslProvider;
+import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Check that Moquette could also handle SSL with OpenSSL provider.
+ */
+public class ServerIntegrationOpenSSLTest extends ServerIntegrationSSLTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIntegrationOpenSSLTest.class);
+
+    @BeforeClass
+    public static void beforeTests() {
+        LOG.info("try to initialize OpenSSL native library");
+        OpenSsl.ensureAvailability();
+        LOG.info("OpenSSL initialized");
+    }
+
+    @Override
+    protected void startServer() throws IOException {
+        String file = getClass().getResource("/").getPath();
+        System.setProperty("moquette.path", file);
+        m_server = new Server();
+        Properties sslProps = new Properties();
+
+        sslProps.put(BrokerConstants.SSL_PROVIDER, SslProvider.OPENSSL.name());
+        sslProps.put(BrokerConstants.NEED_CLIENT_AUTH, "true");
+
+        sslProps.put(BrokerConstants.SSL_PORT_PROPERTY_NAME, "8883");
+        sslProps.put(BrokerConstants.JKS_PATH_PROPERTY_NAME, "serverkeystore.jks");
+        sslProps.put(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
+        sslProps.put(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
+        sslProps.put(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME, IntegrationUtils.localH2MvStoreDBPath());
+        m_server.startServer(sslProps);
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
@@ -23,6 +23,7 @@ import com.echostreams.pulsar.mqtt.broker.config.MemoryConfig;
 import com.echostreams.pulsar.mqtt.broker.security.AcceptAllAuthenticator;
 import com.echostreams.pulsar.mqtt.broker.security.IAuthorizatorPolicy;
 import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import com.echostreams.pulsar.mqtt.interception.InterceptHandler;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
@@ -38,6 +39,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -46,7 +49,7 @@ import static org.junit.Assert.*;
 public class ServerIntegrationPahoCanPublishOnReadBlockedTopicTest {
 
     private static final Logger LOG =
-        LoggerFactory.getLogger(ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.class);
+            LoggerFactory.getLogger(ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.class);
 
     static MqttClientPersistence s_dataStore;
     static MqttClientPersistence s_pubDataStore;
@@ -57,6 +60,8 @@ public class ServerIntegrationPahoCanPublishOnReadBlockedTopicTest {
     MessageCollector m_messagesCollector;
     IConfig m_config;
     private boolean canRead;
+
+    public static final List<InterceptHandler> EMPTY_OBSERVERS = Collections.emptyList();
 
     @BeforeClass
     public static void beforeTests() {
@@ -73,7 +78,7 @@ public class ServerIntegrationPahoCanPublishOnReadBlockedTopicTest {
         canRead = true;
 
         final IAuthorizatorPolicy switchingAuthorizator = new IAuthorizatorPolicy() {
-//            int callCount = 0;
+            //            int callCount = 0;
             @Override
             public boolean canWrite(Topic topic, String user, String client) {
                 return true;
@@ -128,11 +133,11 @@ public class ServerIntegrationPahoCanPublishOnReadBlockedTopicTest {
 
         // Exercise
         MqttPublishMessage message = MqttMessageBuilders.publish()
-            .topicName("/topic")
-            .retained(true)
-            .qos(MqttQoS.AT_MOST_ONCE)
-            .payload(Unpooled.copiedBuffer("Hello World!!".getBytes(UTF_8)))
-            .build();
+                .topicName("/topic")
+                .retained(true)
+                .qos(MqttQoS.AT_MOST_ONCE)
+                .payload(Unpooled.copiedBuffer("Hello World!!".getBytes(UTF_8)))
+                .build();
 
         m_server.internalPublish(message, "INTRLPUB");
 

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.Server;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import com.echostreams.pulsar.mqtt.broker.config.MemoryConfig;
+import com.echostreams.pulsar.mqtt.broker.security.AcceptAllAuthenticator;
+import com.echostreams.pulsar.mqtt.broker.security.IAuthorizatorPolicy;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.*;
+
+public class ServerIntegrationPahoCanPublishOnReadBlockedTopicTest {
+
+    private static final Logger LOG =
+        LoggerFactory.getLogger(ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.class);
+
+    static MqttClientPersistence s_dataStore;
+    static MqttClientPersistence s_pubDataStore;
+
+    Server m_server;
+    IMqttClient m_client;
+    IMqttClient m_publisher;
+    MessageCollector m_messagesCollector;
+    IConfig m_config;
+    private boolean canRead;
+
+    @BeforeClass
+    public static void beforeTests() {
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        s_dataStore = new MqttDefaultFilePersistence(tmpDir);
+        s_pubDataStore = new MqttDefaultFilePersistence(tmpDir + File.separator + "publisher");
+    }
+
+    protected void startServer() throws IOException {
+        m_server = new Server();
+        final Properties configProps = IntegrationUtils.prepareTestProperties();
+        configProps.setProperty(BrokerConstants.REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT, "true");
+        m_config = new MemoryConfig(configProps);
+        canRead = true;
+
+        final IAuthorizatorPolicy switchingAuthorizator = new IAuthorizatorPolicy() {
+//            int callCount = 0;
+            @Override
+            public boolean canWrite(Topic topic, String user, String client) {
+                return true;
+            }
+
+            @Override
+            public boolean canRead(Topic topic, String user, String client) {
+                return canRead;
+            }
+        };
+
+        m_server.startServer(m_config, EMPTY_OBSERVERS, null, new AcceptAllAuthenticator(), switchingAuthorizator);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        startServer();
+
+        m_client = new MqttClient("tcp://localhost:1883", "TestClient", s_dataStore);
+        m_messagesCollector = new MessageCollector();
+        m_client.setCallback(m_messagesCollector);
+
+        m_publisher = new MqttClient("tcp://localhost:1883", "Publisher", s_pubDataStore);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (m_client != null && m_client.isConnected()) {
+            m_client.disconnect();
+        }
+
+        if (m_publisher != null && m_publisher.isConnected()) {
+            m_publisher.disconnect();
+        }
+
+        stopServer();
+    }
+
+    private void stopServer() {
+        m_server.stopServer();
+    }
+
+    // TODO move this functional test into unit/integration
+    @Test
+    public void shouldNotInternalPublishOnReadBlockedSubscriptionTopic() throws Exception {
+        LOG.info("*** shouldNotInternalPublishOnReadBlockedSubscriptionTopic ***");
+
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setCleanSession(false);
+        m_client.connect(options);
+        m_client.subscribe("/topic", 0);
+
+        // Exercise
+        MqttPublishMessage message = MqttMessageBuilders.publish()
+            .topicName("/topic")
+            .retained(true)
+            .qos(MqttQoS.AT_MOST_ONCE)
+            .payload(Unpooled.copiedBuffer("Hello World!!".getBytes(UTF_8)))
+            .build();
+
+        m_server.internalPublish(message, "INTRLPUB");
+
+        final MqttMessage mqttMessage = m_messagesCollector.waitMessage(1);
+        assertNotNull(mqttMessage);
+
+        m_client.disconnect();
+        // switch the authorizator
+        canRead = false;
+
+        // Exercise 2
+        m_client.connect(options);
+        try {
+            m_client.subscribe("/topic", 0);
+            fail();
+        } catch (MqttException mex) {
+            // it's OK, the subscribed should fail with error code 128
+        }
+
+        m_server.internalPublish(message, "INTRLPUB");
+
+        // verify the message is not published
+        final MqttMessage mqttMessage2 = m_messagesCollector.waitMessage(1);
+        assertNull("No message MUST be received", mqttMessage2);
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationPahoTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationPahoTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import com.echostreams.pulsar.mqtt.broker.Server;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import com.echostreams.pulsar.mqtt.broker.config.MemoryConfig;
+import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
+import org.junit.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.*;
+
+public class ServerIntegrationPahoTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIntegrationPahoTest.class);
+
+    static MqttClientPersistence s_dataStore;
+    static MqttClientPersistence s_pubDataStore;
+
+    Server m_server;
+    IMqttClient m_client;
+    IMqttClient m_publisher;
+    MessageCollector m_messagesCollector;
+    IConfig m_config;
+
+    @BeforeClass
+    public static void beforeTests() {
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        s_dataStore = new MqttDefaultFilePersistence(tmpDir);
+        s_pubDataStore = new MqttDefaultFilePersistence(tmpDir + File.separator + "publisher");
+    }
+
+    protected void startServer() throws IOException {
+        m_server = new Server();
+        final Properties configProps = IntegrationUtils.prepareTestProperties();
+        m_config = new MemoryConfig(configProps);
+        m_server.startServer(m_config);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        startServer();
+
+        m_client = new MqttClient("tcp://localhost:1883", "TestClient", s_dataStore);
+        m_messagesCollector = new MessageCollector();
+        m_client.setCallback(m_messagesCollector);
+
+        m_publisher = new MqttClient("tcp://localhost:1883", "Publisher", s_pubDataStore);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (m_client != null && m_client.isConnected()) {
+            m_client.disconnect();
+        }
+
+        if (m_publisher != null && m_publisher.isConnected()) {
+            m_publisher.disconnect();
+        }
+
+        stopServer();
+
+        IntegrationUtils.clearTestStorage();
+    }
+
+    private void stopServer() {
+        m_server.stopServer();
+    }
+
+    @Ignore("This test hasn't any meaning using in memory storage service")
+    @Test
+    public void testCleanSession_maintainClientSubscriptions_withServerRestart() throws Exception {
+        LOG.info("*** testCleanSession_maintainClientSubscriptions_withServerRestart ***");
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setCleanSession(false);
+        m_client.connect(options);
+        m_client.subscribe("/topic", 0);
+        m_client.disconnect();
+
+        m_server.stopServer();
+
+        m_server.startServer(IntegrationUtils.prepareTestProperties());
+
+        // reconnect and publish
+        m_client.connect(options);
+        m_client.publish("/topic", "Test my payload".getBytes(UTF_8), 0, false);
+
+        assertEquals("/topic", m_messagesCollector.getTopic());
+    }
+
+    /**
+     * subscriber A connect and subscribe on "a/b" QoS 1 subscriber B connect and subscribe on "a/+"
+     * BUT with QoS 2 publisher connects and send a message "hello" on "a/b" subscriber A must
+     * receive a notification with QoS1 subscriber B must receive a notification with QoS2
+     */
+    @Test
+    public void checkSubscribersGetCorrectQosNotifications() throws Exception {
+        LOG.info("*** checkSubscribersGetCorrectQosNotifications ***");
+        String tmpDir = System.getProperty("java.io.tmpdir");
+
+        MqttClientPersistence dsSubscriberA = new MqttDefaultFilePersistence(tmpDir + File.separator + "subscriberA");
+
+        MqttClient subscriberA = new MqttClient("tcp://localhost:1883", "SubscriberA", dsSubscriberA);
+        MessageCollector cbSubscriberA = new MessageCollector();
+        subscriberA.setCallback(cbSubscriberA);
+        subscriberA.connect();
+        subscriberA.subscribe("a/b", 1);
+
+        MqttClientPersistence dsSubscriberB = new MqttDefaultFilePersistence(tmpDir + File.separator + "subscriberB");
+
+        MqttClient subscriberB = new MqttClient("tcp://localhost:1883", "SubscriberB", dsSubscriberB);
+        MessageCollector cbSubscriberB = new MessageCollector();
+        subscriberB.setCallback(cbSubscriberB);
+        subscriberB.connect();
+        subscriberB.subscribe("a/+", 2);
+
+        m_client.connect();
+        m_client.publish("a/b", "Hello world MQTT!!".getBytes(UTF_8), 2, false);
+
+        MqttMessage messageOnA = cbSubscriberA.waitMessage(1);
+        assertEquals("Hello world MQTT!!", new String(messageOnA.getPayload(), UTF_8));
+        assertEquals(1, messageOnA.getQos());
+        subscriberA.disconnect();
+
+        MqttMessage messageOnB = cbSubscriberB.waitMessage(1);
+        assertNotNull("MUST be a received message", messageOnB);
+        assertEquals("Hello world MQTT!!", new String(messageOnB.getPayload(), UTF_8));
+        assertEquals(2, messageOnB.getQos());
+        subscriberB.disconnect();
+    }
+
+    @Test
+    public void testSubcriptionDoesntStayActiveAfterARestart() throws Exception {
+        LOG.info("*** testSubcriptionDoesntStayActiveAfterARestart ***");
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        // clientForSubscribe1 connect and subscribe to /topic QoS2
+        MqttClientPersistence dsSubscriberA = new MqttDefaultFilePersistence(
+                tmpDir + File.separator + "clientForSubscribe1");
+
+        MqttClient clientForSubscribe1 = new MqttClient("tcp://localhost:1883", "clientForSubscribe1", dsSubscriberA);
+        MessageCollector cbSubscriber1 = new MessageCollector();
+        clientForSubscribe1.setCallback(cbSubscriber1);
+        clientForSubscribe1.connect();
+        clientForSubscribe1.subscribe("topic", 0);
+
+        // integration stop
+        m_server.stopServer();
+        System.out.println("\n\n SEVER REBOOTING \n\n");
+        // integration start
+        startServer();
+
+        // clientForSubscribe2 connect and subscribe to /topic QoS2
+        MqttClientPersistence dsSubscriberB = new MqttDefaultFilePersistence(
+                tmpDir + File.separator + "clientForSubscribe2");
+        MqttClient clientForSubscribe2 = new MqttClient("tcp://localhost:1883", "clientForSubscribe2", dsSubscriberB);
+        MessageCollector cbSubscriber2 = new MessageCollector();
+        clientForSubscribe2.setCallback(cbSubscriber2);
+        clientForSubscribe2.connect();
+        clientForSubscribe2.subscribe("topic", 0);
+
+        // clientForPublish publish on /topic with QoS2 a message
+        MqttClientPersistence dsSubscriberPUB = new MqttDefaultFilePersistence(
+                tmpDir + File.separator + "clientForPublish");
+        MqttClient clientForPublish = new MqttClient("tcp://localhost:1883", "clientForPublish", dsSubscriberPUB);
+        clientForPublish.connect();
+        clientForPublish.publish("topic", "Hello".getBytes(UTF_8), 2, true);
+
+        // verify clientForSubscribe1 doesn't receive a notification but clientForSubscribe2 yes
+        LOG.info("Before waiting to receive 1 sec from {}", clientForSubscribe1.getClientId());
+        assertFalse(clientForSubscribe1.isConnected());
+        assertTrue(clientForSubscribe2.isConnected());
+        LOG.info("Waiting to receive 1 sec from {}", clientForSubscribe2.getClientId());
+        MqttMessage messageOnB = cbSubscriber2.waitMessage(1);
+        assertEquals("Hello", new String(messageOnB.getPayload(), UTF_8));
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationQoSValidationTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationQoSValidationTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import com.echostreams.pulsar.mqtt.broker.Server;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import com.echostreams.pulsar.mqtt.broker.config.MemoryConfig;
+import org.eclipse.paho.client.mqttv3.IMqttClient;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+public class ServerIntegrationQoSValidationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIntegrationPahoTest.class);
+
+    Server m_server;
+
+    IMqttClient m_subscriber;
+    IMqttClient m_publisher;
+    MessageCollector m_callback;
+    IConfig m_config;
+
+    protected void startServer() throws IOException {
+        m_server = new Server();
+        final Properties configProps = IntegrationUtils.prepareTestProperties();
+        m_config = new MemoryConfig(configProps);
+        m_server.startServer(m_config);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        startServer();
+
+        m_subscriber = new MqttClient("tcp://localhost:1883", "Subscriber", new MemoryPersistence());
+        m_callback = new MessageCollector();
+        m_subscriber.setCallback(m_callback);
+        m_subscriber.connect();
+
+        m_publisher = new MqttClient("tcp://localhost:1883", "Publisher", new MemoryPersistence());
+        m_publisher.connect();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (m_publisher.isConnected()) {
+            m_publisher.disconnect();
+        }
+
+        if (m_subscriber.isConnected()) {
+            m_subscriber.disconnect();
+        }
+
+        m_server.stopServer();
+        IntegrationUtils.clearTestStorage();
+    }
+
+    @Test
+    public void checkSubscriberQoS0ReceiveQoS0publishes() throws Exception {
+        LOG.info("*** checkSubscriberQoS0ReceiveQoS0publishes ***");
+        m_subscriber.subscribe("/topic", 0);
+
+        m_publisher.publish("/topic", "Hello world MQTT QoS0".getBytes(UTF_8), 0, false);
+        MqttMessage message = m_callback.waitMessage(1);
+        assertEquals("Hello world MQTT QoS0", message.toString());
+        assertEquals(0, message.getQos());
+    }
+
+    @Test
+    public void checkSubscriberQoS0ReceiveQoS1publishes_downgrade() throws Exception {
+        LOG.info("*** checkSubscriberQoS0ReceiveQoS1publishes_downgrade ***");
+        m_subscriber.subscribe("/topic", 0);
+
+        m_publisher.publish("/topic", "Hello world MQTT QoS1".getBytes(UTF_8), 1, false);
+        MqttMessage message = m_callback.waitMessage(1);
+        assertEquals("Hello world MQTT QoS1", message.toString());
+        assertEquals(0, message.getQos());
+    }
+
+    @Test
+    public void checkSubscriberQoS0ReceiveQoS2publishes_downgrade() throws Exception {
+        LOG.info("*** checkSubscriberQoS0ReceiveQoS2publishes_downgrade ***");
+        m_subscriber.subscribe("/topic", 0);
+
+        m_publisher.publish("/topic", "Hello world MQTT QoS2".getBytes(UTF_8), 2, false);
+        MqttMessage message = m_callback.waitMessage(1);
+        assertEquals("Hello world MQTT QoS2", message.toString());
+        assertEquals(0, message.getQos());
+    }
+
+    @Test
+    public void checkSubscriberQoS1ReceiveQoS0publishes() throws Exception {
+        LOG.info("*** checkSubscriberQoS1ReceiveQoS0publishes ***");
+        m_subscriber.subscribe("/topic", 1);
+
+        m_publisher.publish("/topic", "Hello world MQTT QoS0".getBytes(UTF_8), 0, false);
+        MqttMessage message = m_callback.waitMessage(1);
+        assertEquals("Hello world MQTT QoS0", message.toString());
+        assertEquals(0, message.getQos());
+    }
+
+    @Test
+    public void checkSubscriberQoS1ReceiveQoS1publishes() throws Exception {
+        LOG.info("*** checkSubscriberQoS1ReceiveQoS1publishes ***");
+        m_subscriber.subscribe("/topic", 1);
+
+        m_publisher.publish("/topic", "Hello world MQTT QoS1".getBytes(UTF_8), 1, false);
+        MqttMessage message = m_callback.waitMessage(1);
+        assertEquals("Hello world MQTT QoS1", message.toString());
+        assertEquals(1, message.getQos());
+    }
+
+    @Test
+    public void checkSubscriberQoS1ReceiveQoS2publishes_downgrade() throws Exception {
+        LOG.info("*** checkSubscriberQoS1ReceiveQoS2publishes_downgrade ***");
+        m_subscriber.subscribe("/topic", 1);
+
+        m_publisher.publish("/topic", "Hello world MQTT QoS2".getBytes(UTF_8), 2, false);
+        MqttMessage message = m_callback.waitMessage(1);
+        assertEquals("Hello world MQTT QoS2", message.toString());
+        assertEquals(1, message.getQos());
+    }
+
+    @Test
+    public void checkSubscriberQoS2ReceiveQoS0publishes() throws Exception {
+        LOG.info("*** checkSubscriberQoS2ReceiveQoS0publishes ***");
+        m_subscriber.subscribe("/topic", 2);
+
+        m_publisher.publish("/topic", "Hello world MQTT QoS2".getBytes(UTF_8), 0, false);
+        MqttMessage message = m_callback.waitMessage(1);
+        assertEquals("Hello world MQTT QoS2", message.toString());
+        assertEquals(0, message.getQos());
+    }
+
+    @Test
+    public void checkSubscriberQoS2ReceiveQoS1publishes() throws Exception {
+        LOG.info("*** checkSubscriberQoS2ReceiveQoS1publishes ***");
+        m_subscriber.subscribe("/topic", 2);
+
+        m_publisher.publish("/topic", "Hello world MQTT QoS2".getBytes(UTF_8), 1, false);
+        MqttMessage message = m_callback.waitMessage(1);
+        assertEquals("Hello world MQTT QoS2", message.toString());
+        assertEquals(1, message.getQos());
+    }
+
+    @Test
+    public void checkSubscriberQoS2ReceiveQoS2publishes() throws Exception {
+        LOG.info("*** checkSubscriberQoS2ReceiveQoS2publishes ***");
+        m_subscriber.subscribe("/topic", 2);
+
+        m_publisher.publish("/topic", "Hello world MQTT QoS2".getBytes(UTF_8), 2, false);
+        MqttMessage message = m_callback.waitMessage(1);
+        assertEquals("Hello world MQTT QoS2", message.toString());
+        assertEquals(2, message.getQos());
+    }
+
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationRestartTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationRestartTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import com.echostreams.pulsar.mqtt.broker.Server;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import com.echostreams.pulsar.mqtt.broker.config.MemoryConfig;
+import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ServerIntegrationRestartTest {
+
+    static MqttClientPersistence s_dataStore;
+    static MqttClientPersistence s_pubDataStore;
+    static MqttConnectOptions CLEAN_SESSION_OPT = new MqttConnectOptions();
+
+    Server m_server;
+    IMqttClient m_subscriber;
+    IMqttClient m_publisher;
+    IConfig m_config;
+    MessageCollector m_messageCollector;
+
+    protected void startServer() throws IOException {
+        m_server = new Server();
+        final Properties configProps = IntegrationUtils.prepareTestProperties();
+        m_config = new MemoryConfig(configProps);
+        m_server.startServer(m_config);
+    }
+
+    @BeforeClass
+    public static void beforeTests() {
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        s_dataStore = new MqttDefaultFilePersistence(tmpDir);
+        s_pubDataStore = new MqttDefaultFilePersistence(tmpDir + File.separator + "publisher");
+        CLEAN_SESSION_OPT.setCleanSession(false);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        startServer();
+
+        m_subscriber = new MqttClient("tcp://localhost:1883", "Subscriber", s_dataStore);
+        m_messageCollector = new MessageCollector();
+        m_subscriber.setCallback(m_messageCollector);
+
+        m_publisher = new MqttClient("tcp://localhost:1883", "Publisher", s_pubDataStore);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (m_subscriber != null && m_subscriber.isConnected()) {
+            m_subscriber.disconnect();
+        }
+
+        if (m_publisher != null && m_publisher.isConnected()) {
+            m_publisher.disconnect();
+        }
+
+        m_server.stopServer();
+
+        IntegrationUtils.clearTestStorage();
+    }
+
+    @Test
+    public void checkRestartCleanSubscriptionTree() throws Exception {
+        // subscribe to /topic
+        m_subscriber.connect(CLEAN_SESSION_OPT);
+        m_subscriber.subscribe("/topic", 1);
+        m_subscriber.disconnect();
+
+        // shutdown the integration
+        m_server.stopServer();
+
+        // restart the integration
+        m_server.startServer(IntegrationUtils.prepareTestProperties());
+
+        // reconnect the Subscriber subscribing to the same /topic but different QoS
+        m_subscriber.connect(CLEAN_SESSION_OPT);
+        m_subscriber.subscribe("/topic", 2);
+
+        // should be just one registration so a publisher receive one notification
+        m_publisher.connect(CLEAN_SESSION_OPT);
+        m_publisher.publish("/topic", "Hello world MQTT!!".getBytes(UTF_8), 1, false);
+
+        // read the messages
+        MqttMessage msg = m_messageCollector.waitMessage(1);
+        assertEquals("Hello world MQTT!!", new String(msg.getPayload(), UTF_8));
+        // no more messages on the same topic will be received
+        assertNull(m_messageCollector.waitMessage(1));
+    }
+
+    @Test
+    public void checkDontPublishInactiveClientsAfterServerRestart() throws Exception {
+        IMqttClient conn = subscribeAndPublish("/topic");
+        conn.disconnect();
+
+        // shutdown the integration
+        m_server.stopServer();
+
+        // restart the integration
+        m_server.startServer(IntegrationUtils.prepareTestProperties());
+
+        m_publisher.connect();
+        m_publisher.publish("/topic", "Hello world MQTT!!".getBytes(UTF_8), 0, false);
+    }
+
+    @Test
+    public void testClientDoesntRemainSubscribedAfterASubscriptionAndServerRestart() throws Exception {
+        // subscribe to /topic
+        m_subscriber.connect();
+        // subscribe /topic
+        m_subscriber.subscribe("/topic", 0);
+        // unsubscribe from /topic
+        m_subscriber.unsubscribe("/topic");
+        m_subscriber.disconnect();
+
+        // shutdown the integration
+        m_server.stopServer();
+
+        // restart the integration
+        m_server.startServer(IntegrationUtils.prepareTestProperties());
+        // subscriber reconnects
+        m_subscriber = new MqttClient("tcp://localhost:1883", "Subscriber", s_dataStore);
+        m_subscriber.setCallback(m_messageCollector);
+        m_subscriber.connect();
+
+        // publisher publishes on /topic
+        m_publisher = new MqttClient("tcp://localhost:1883", "Publisher", s_pubDataStore);
+        m_publisher.connect();
+        m_publisher.publish("/topic", "Hello world MQTT!!".getBytes(UTF_8), 1, false);
+
+        // Expected
+        // the subscriber doesn't get notified (it's fully unsubscribed)
+        assertNull(m_messageCollector.waitMessage(1));
+    }
+
+    /**
+     * Connect subscribe to topic and publish on the same topic
+     */
+    private IMqttClient subscribeAndPublish(String topic) throws Exception {
+        IMqttClient client = new MqttClient("tcp://localhost:1883", "SubPub");
+        MessageCollector collector = new MessageCollector();
+        client.setCallback(collector);
+        client.connect();
+        client.subscribe(topic, 1);
+        client.publish(topic, "Hello world MQTT!!".getBytes(UTF_8), 0, false);
+        MqttMessage msg = collector.waitMessage(1);
+        assertEquals("Hello world MQTT!!", new String(msg.getPayload(), UTF_8));
+        return client;
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationSSLClientAuthTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationSSLClientAuthTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.Server;
+import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
+import org.junit.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.*;
+import java.security.cert.CertificateException;
+import java.util.Properties;
+
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Check that Moquette could also handle SSL with client authentication.
+ *
+ * <p>
+ * Create certificates needed for client authentication
+ *
+ * <pre>
+ * # generate integration certificate chain (valid for 10000 days)
+ * keytool -genkeypair -alias signedtestserver -dname cn=moquette.eclipse.org -keyalg RSA -keysize 2048 \
+ * -keystore signedserverkeystore.jks -keypass passw0rdsrv -storepass passw0rdsrv -validity 10000
+ * keytool -genkeypair -alias signedtestserver_sub -dname cn=moquette.eclipse.org -keyalg RSA -keysize 2048 \
+ * -keystore signedserverkeystore.jks -keypass passw0rdsrv -storepass passw0rdsrv
+ *
+ * # sign integration subcertificate with integration certificate (valid for 10000 days)
+ * keytool -certreq -alias signedtestserver_sub -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv | \
+ * keytool -gencert -alias signedtestserver -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv -validity 10000 | \
+ * keytool -importcert -alias signedtestserver_sub -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv
+ *
+ * # generate client keypair
+ * keytool -genkeypair -alias signedtestclient -dname cn=moquette.eclipse.org -keyalg RSA -keysize 2048 \
+ * -keystore signedclientkeystore.jks -keypass passw0rd -storepass passw0rd
+ *
+ * # create signed client certificate with integration subcertificate and import to client keystore (valid for 10000 days)
+ * keytool -certreq -alias signedtestclient -keystore signedclientkeystore.jks -keypass passw0rd -storepass passw0rd | \
+ * keytool -gencert -alias signedtestserver_sub -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv -validity 10000 | \
+ * keytool -importcert -alias signedtestclient -keystore signedclientkeystore.jks -keypass passw0rd \
+ * -storepass passw0rd -noprompt
+ *
+ * # import integration certificates into signed truststore
+ * keytool -exportcert -alias signedtestserver -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv | \
+ * keytool -importcert -trustcacerts -noprompt -alias signedtestserver -keystore signedclientkeystore.jks \
+ * -keypass passw0rd -storepass passw0rd
+ * keytool -exportcert -alias signedtestserver_sub -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv | \
+ * keytool -importcert -trustcacerts -noprompt -alias signedtestserver_sub -keystore signedclientkeystore.jks \
+ * -keypass passw0rd -storepass passw0rd
+ *
+ * # create unsigned client certificate (valid for 10000 days)
+ * keytool -genkeypair -alias unsignedtestclient -dname cn=moquette.eclipse.org -validity 10000 -keyalg RSA \
+ * -keysize 2048 -keystore unsignedclientkeystore.jks -keypass passw0rd -storepass passw0rd
+ *
+ * # import integration certificates into unsigned truststore
+ * keytool -exportcert -alias signedtestserver -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv | \
+ * keytool -importcert -trustcacerts -noprompt -alias signedtestserver -keystore unsignedclientkeystore.jks \
+ * -keypass passw0rd -storepass passw0rd
+ * keytool -exportcert -alias signedtestserver_sub -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv | \
+ * keytool -importcert -trustcacerts -noprompt -alias signedtestserver_sub -keystore unsignedclientkeystore.jks \
+ * -keypass passw0rd -storepass passw0rd
+ * </pre>
+ * </p>
+ */
+public class ServerIntegrationSSLClientAuthTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIntegrationSSLClientAuthTest.class);
+
+    Server m_server;
+    static MqttClientPersistence s_dataStore;
+
+    IMqttClient m_client;
+    MessageCollector m_callback;
+    static String backup;
+
+    @BeforeClass
+    public static void beforeTests() {
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        s_dataStore = new MqttDefaultFilePersistence(tmpDir);
+        backup = System.getProperty("moquette.path");
+    }
+
+    @AfterClass
+    public static void afterTests() {
+        if (backup == null)
+            System.clearProperty("moquette.path");
+        else
+            System.setProperty("moquette.path", backup);
+    }
+
+    protected void startServer() throws IOException {
+        String file = getClass().getResource("/").getPath();
+        System.setProperty("moquette.path", file);
+        m_server = new Server();
+
+        Properties sslProps = new Properties();
+        sslProps.put(BrokerConstants.SSL_PORT_PROPERTY_NAME, "8883");
+        sslProps.put(BrokerConstants.JKS_PATH_PROPERTY_NAME, "signedserverkeystore.jks");
+        sslProps.put(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
+        sslProps.put(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
+        sslProps.put(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME, IntegrationUtils.localH2MvStoreDBPath());
+        sslProps.put(BrokerConstants.NEED_CLIENT_AUTH, "true");
+        m_server.startServer(sslProps);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        String dbPath = IntegrationUtils.localH2MvStoreDBPath();
+        File dbFile = new File(dbPath);
+        assertFalse(String.format("The DB storagefile %s already exists", dbPath), dbFile.exists());
+
+        startServer();
+
+        m_client = new MqttClient("ssl://localhost:8883", "TestClient", s_dataStore);
+        // m_client = new MqttClient("ssl://test.mosquitto.org:8883", "TestClient", s_dataStore);
+
+        m_callback = new MessageCollector();
+        m_client.setCallback(m_callback);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (m_client != null && m_client.isConnected()) {
+            m_client.disconnect();
+        }
+
+        if (m_server != null) {
+            m_server.stopServer();
+        }
+        IntegrationUtils.clearTestStorage();
+    }
+
+    @Test
+    public void checkClientAuthentication() throws Exception {
+        LOG.info("*** checkClientAuthentication ***");
+        SSLSocketFactory ssf = configureSSLSocketFactory("signedclientkeystore.jks");
+
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setSocketFactory(ssf);
+        m_client.connect(options);
+        m_client.subscribe("/topic", 0);
+        m_client.disconnect();
+    }
+
+    @Test(expected = MqttException.class)
+    public void checkClientAuthenticationFail() throws Exception {
+        LOG.info("*** checkClientAuthenticationFail ***");
+        SSLSocketFactory ssf = configureSSLSocketFactory("unsignedclientkeystore.jks");
+
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setSocketFactory(ssf);
+        // actual a "Broken pipe" is thrown, this is not very specific.
+        try {
+            m_client.connect(options);
+        } catch (MqttException e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    private SSLSocketFactory configureSSLSocketFactory(String keystore) throws KeyManagementException,
+            NoSuchAlgorithmException, UnrecoverableKeyException, IOException, CertificateException, KeyStoreException {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        InputStream jksInputStream = getClass().getClassLoader().getResourceAsStream(keystore);
+        ks.load(jksInputStream, "passw0rd".toCharArray());
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, "passw0rd".toCharArray());
+
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(ks);
+
+        SSLContext sc = SSLContext.getInstance("TLS");
+        TrustManager[] trustManagers = tmf.getTrustManagers();
+        sc.init(kmf.getKeyManagers(), trustManagers, null);
+
+        SSLSocketFactory ssf = sc.getSocketFactory();
+        return ssf;
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationSSLTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationSSLTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.Server;
+import org.eclipse.paho.client.mqttv3.*;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
+import org.junit.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.*;
+import java.security.cert.CertificateException;
+import java.util.Properties;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Check that Moquette could also handle SSL.
+ */
+public class ServerIntegrationSSLTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIntegrationSSLTest.class);
+
+    Server m_server;
+    static MqttClientPersistence s_dataStore;
+
+    IMqttClient m_client;
+    MessageCollector m_callback;
+
+    static String backup;
+
+    @BeforeClass
+    public static void beforeTests() {
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        s_dataStore = new MqttDefaultFilePersistence(tmpDir);
+        backup = System.getProperty("moquette.path");
+    }
+
+    @AfterClass
+    public static void afterTests() {
+        if (backup == null)
+            System.clearProperty("moquette.path");
+        else
+            System.setProperty("moquette.path", backup);
+    }
+
+    protected void startServer() throws IOException {
+        String file = getClass().getResource("/").getPath();
+        System.setProperty("moquette.path", file);
+        m_server = new Server();
+
+        Properties sslProps = new Properties();
+        sslProps.put(BrokerConstants.SSL_PORT_PROPERTY_NAME, "8883");
+        sslProps.put(BrokerConstants.JKS_PATH_PROPERTY_NAME, "serverkeystore.jks");
+        sslProps.put(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
+        sslProps.put(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
+        sslProps.put(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME, IntegrationUtils.localH2MvStoreDBPath());
+        m_server.startServer(sslProps);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        String dbPath = IntegrationUtils.localH2MvStoreDBPath();
+        File dbFile = new File(dbPath);
+        assertFalse(String.format("The DB storagefile %s already exists", dbPath), dbFile.exists());
+
+        startServer();
+
+        m_client = new MqttClient("ssl://localhost:8883", "TestClient", s_dataStore);
+        // m_client = new MqttClient("ssl://test.mosquitto.org:8883", "TestClient", s_dataStore);
+
+        m_callback = new MessageCollector();
+        m_client.setCallback(m_callback);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (m_client != null && m_client.isConnected()) {
+            m_client.disconnect();
+        }
+
+        if (m_server != null) {
+            m_server.stopServer();
+        }
+        IntegrationUtils.clearTestStorage();
+    }
+
+    @Test
+    public void checkSupportSSL() throws Exception {
+        LOG.info("*** checkSupportSSL ***");
+        SSLSocketFactory ssf = configureSSLSocketFactory();
+
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setSocketFactory(ssf);
+        m_client.connect(options);
+        m_client.subscribe("/topic", 0);
+        m_client.disconnect();
+    }
+
+    @Test
+    public void checkSupportSSLForMultipleClient() throws Exception {
+        LOG.info("*** checkSupportSSLForMultipleClient ***");
+        SSLSocketFactory ssf = configureSSLSocketFactory();
+
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setSocketFactory(ssf);
+        m_client.connect(options);
+        m_client.subscribe("/topic", 0);
+
+        MqttClient secondClient = new MqttClient("ssl://localhost:8883", "secondTestClient", new MemoryPersistence());
+        MqttConnectOptions secondClientOptions = new MqttConnectOptions();
+        secondClientOptions.setSocketFactory(ssf);
+        secondClient.connect(secondClientOptions);
+        secondClient.publish("/topic", new MqttMessage("message".getBytes(UTF_8)));
+        secondClient.disconnect();
+
+        m_client.disconnect();
+    }
+
+    /**
+     * keystore generated into test/resources with command:
+     *
+     * keytool -keystore clientkeystore.jks -alias testclient -genkey -keyalg RSA -> mandatory to
+     * put the name surname -> password is passw0rd -> type yes at the end
+     *
+     * to generate the crt file from the keystore -- keytool -certreq -alias testclient -keystore
+     * clientkeystore.jks -file testclient.csr
+     *
+     * keytool -export -alias testclient -keystore clientkeystore.jks -file testclient.crt
+     *
+     * to import an existing certificate: keytool -keystore clientkeystore.jks -import -alias
+     * testclient -file testclient.crt -trustcacerts
+     */
+    private SSLSocketFactory configureSSLSocketFactory() throws KeyManagementException, NoSuchAlgorithmException,
+            UnrecoverableKeyException, IOException, CertificateException, KeyStoreException {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        InputStream jksInputStream = getClass().getClassLoader().getResourceAsStream("clientkeystore.jks");
+        ks.load(jksInputStream, "passw0rd".toCharArray());
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, "passw0rd".toCharArray());
+
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(ks);
+
+        SSLContext sc = SSLContext.getInstance("TLS");
+        TrustManager[] trustManagers = tmf.getTrustManagers();
+        sc.init(kmf.getKeyManagers(), trustManagers, null);
+
+        SSLSocketFactory ssf = sc.getSocketFactory();
+        return ssf;
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationWebSocketTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerIntegrationWebSocketTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.Server;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import com.echostreams.pulsar.mqtt.broker.config.MemoryConfig;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration test to check the function of Moquette with a WebSocket channel.
+ */
+public class ServerIntegrationWebSocketTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIntegrationWebSocketTest.class);
+
+    Server m_server;
+    WebSocketClient client;
+    IConfig m_config;
+
+    protected void startServer() throws IOException {
+        m_server = new Server();
+        final Properties configProps = IntegrationUtils.prepareTestProperties();
+        configProps
+                .put(BrokerConstants.WEB_SOCKET_PORT_PROPERTY_NAME, Integer.toString(BrokerConstants.WEBSOCKET_PORT));
+        m_config = new MemoryConfig(configProps);
+        m_server.startServer(m_config);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        startServer();
+        client = new WebSocketClient();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.stop();
+        m_server.stopServer();
+        IntegrationUtils.clearTestStorage();
+    }
+
+    @SuppressWarnings("FutureReturnValueIgnored")
+    @Test
+    public void checkPlainConnect() throws Exception {
+        LOG.info("*** checkPlainConnect ***");
+        String destUri = "ws://localhost:" + BrokerConstants.WEBSOCKET_PORT + BrokerConstants.WEBSOCKET_PATH;
+
+        MQTTWebSocket socket = new MQTTWebSocket();
+        client.start();
+        URI echoUri = new URI(destUri);
+        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        client.connect(socket, echoUri, request);
+        LOG.info("Connecting to : {}", echoUri);
+        boolean connected = socket.awaitConnected(4, TimeUnit.SECONDS);
+        LOG.info("Connected was : {}", connected);
+
+        assertTrue(connected);
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerLowlevelMessagesIntegrationTests.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/integration/ServerLowlevelMessagesIntegrationTests.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.integration;
+
+import com.echostreams.pulsar.mqtt.testclient.Client;
+import com.echostreams.pulsar.mqtt.broker.Server;
+import com.echostreams.pulsar.mqtt.broker.config.IConfig;
+import com.echostreams.pulsar.mqtt.broker.config.MemoryConfig;
+import io.netty.handler.codec.mqtt.*;
+import org.awaitility.Awaitility;
+import org.eclipse.paho.client.mqttv3.IMqttClient;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttClientPersistence;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_REFUSED_IDENTIFIER_REJECTED;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.*;
+
+public class ServerLowlevelMessagesIntegrationTests {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServerLowlevelMessagesIntegrationTests.class);
+    static MqttClientPersistence s_dataStore;
+    Server m_server;
+    Client m_client;
+    IMqttClient m_willSubscriber;
+    MessageCollector m_messageCollector;
+    IConfig m_config;
+    MqttMessage receivedMsg;
+
+    protected void startServer() throws IOException {
+        m_server = new Server();
+        final Properties configProps = IntegrationUtils.prepareTestProperties();
+        m_config = new MemoryConfig(configProps);
+        m_server.startServer(m_config);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        startServer();
+        m_client = new Client("localhost");
+        m_willSubscriber = new MqttClient("tcp://localhost:1883", "Subscriber", s_dataStore);
+        m_messageCollector = new MessageCollector();
+        m_willSubscriber.setCallback(m_messageCollector);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        m_client.close();
+        LOG.debug("After raw client close");
+        Thread.sleep(300); // to let the close event pass before integration stop event
+        m_server.stopServer();
+        LOG.debug("After asked integration to stop");
+    }
+
+    @Test
+    public void elapseKeepAliveTime() {
+        int keepAlive = 2; // secs
+
+        MqttConnectMessage connectMessage = createConnectMessage("FAKECLNT", keepAlive);
+
+        /*
+         * ConnectMessage connectMessage = new ConnectMessage();
+         * connectMessage.setProtocolVersion((byte) 3); connectMessage.setClientID("FAKECLNT");
+         * connectMessage.setKeepAlive(keepAlive);
+         */
+        m_client.sendMessage(connectMessage);
+
+        // wait 3 times the keepAlive
+        Awaitility.await()
+            .atMost(3 * keepAlive, TimeUnit.SECONDS)
+            .until(m_client::isConnectionLost);
+    }
+
+    private static MqttConnectMessage createConnectMessage(String clientID, int keepAlive) {
+        MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.CONNECT, false, MqttQoS.AT_MOST_ONCE,
+            false, 0);
+        MqttConnectVariableHeader mqttConnectVariableHeader = new MqttConnectVariableHeader(
+            MqttVersion.MQTT_3_1.protocolName(), MqttVersion.MQTT_3_1.protocolLevel(), false, false, false, 1, false,
+            true, keepAlive);
+        MqttConnectPayload mqttConnectPayload = new MqttConnectPayload(clientID, null, null,
+                                                              null, (byte[]) null);
+        return new MqttConnectMessage(mqttFixedHeader, mqttConnectVariableHeader, mqttConnectPayload);
+    }
+
+    @Test
+    public void testWillMessageIsWiredOnClientKeepAliveExpiry() throws Exception {
+        LOG.info("*** testWillMessageIsWiredOnClientKeepAliveExpiry ***");
+        String willTestamentTopic = "/will/test";
+        String willTestamentMsg = "Bye bye";
+
+        m_willSubscriber.connect();
+        m_willSubscriber.subscribe(willTestamentTopic, 0);
+
+        m_client.clientId("FAKECLNT").connect(willTestamentTopic, willTestamentMsg);
+        long connectTime = System.currentTimeMillis();
+
+        Awaitility.await()
+            .atMost(7, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                // but after the 2 KEEP ALIVE timeout expires it gets fired,
+                // NB it's 1,5 * KEEP_ALIVE so 3 secs and some millis to propagate the message
+                org.eclipse.paho.client.mqttv3.MqttMessage msg = m_messageCollector.getMessageImmediate();
+                assertNotNull("the will message should be fired after keep alive!", msg);
+                // the will message hasn't to be received before the elapsing of Keep Alive timeout
+                assertTrue(System.currentTimeMillis() - connectTime > 3000);
+                assertEquals(willTestamentMsg, new String(msg.getPayload(), UTF_8));
+        });
+
+        m_willSubscriber.disconnect();
+    }
+
+    @Test
+    public void testRejectConnectWithEmptyClientID() throws InterruptedException {
+        LOG.info("*** testRejectConnectWithEmptyClientID ***");
+        m_client.clientId("").connect();
+
+        this.receivedMsg = this.m_client.lastReceivedMessage();
+
+        assertTrue(receivedMsg instanceof MqttConnAckMessage);
+        MqttConnAckMessage connAck = (MqttConnAckMessage) receivedMsg;
+        assertEquals(CONNECTION_REFUSED_IDENTIFIER_REJECTED, connAck.variableHeader().connectReturnCode());
+    }
+
+    @Test
+    public void testWillMessageIsPublishedOnClientBadDisconnection() throws InterruptedException, MqttException {
+        LOG.info("*** testWillMessageIsPublishedOnClientBadDisconnection ***");
+        String willTestamentTopic = "/will/test";
+        String willTestamentMsg = "Bye bye";
+        m_willSubscriber.connect();
+        m_willSubscriber.subscribe(willTestamentTopic, 0);
+        m_client.clientId("FAKECLNT").connect(willTestamentTopic, willTestamentMsg);
+
+        // kill will publisher
+        m_client.close();
+
+        // Verify will testament is published
+        org.eclipse.paho.client.mqttv3.MqttMessage receivedTestament = m_messageCollector.waitMessage(1);
+        assertEquals(willTestamentMsg, new String(receivedTestament.getPayload(), UTF_8));
+        m_willSubscriber.disconnect();
+    }
+
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/interception/BrokerInterceptorTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/interception/BrokerInterceptorTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.interception;
+
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Subscription;
+import com.echostreams.pulsar.mqtt.broker.subscriptions.Topic;
+import com.echostreams.pulsar.mqtt.interception.messages.*;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.refEq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class BrokerInterceptorTest {
+
+    // value to check for changes after every notification
+    private static final AtomicInteger n = new AtomicInteger(0);
+
+    // Interceptor loaded with a custom InterceptHandler special for the tests
+    private static final class MockObserver implements InterceptHandler {
+
+        @Override
+        public String getID() {
+            return "MockObserver";
+        }
+
+        @Override
+        public Class<?>[] getInterceptedMessageTypes() {
+            return ALL_MESSAGE_TYPES;
+        }
+
+        @Override
+        public void onConnect(InterceptConnectMessage msg) {
+            n.set(40);
+        }
+
+        @Override
+        public void onDisconnect(InterceptDisconnectMessage msg) {
+            n.set(50);
+        }
+
+        @Override
+        public void onConnectionLost(InterceptConnectionLostMessage msg) {
+            n.set(30);
+        }
+
+        @Override
+        public void onPublish(InterceptPublishMessage msg) {
+            n.set(60);
+        }
+
+        @Override
+        public void onSubscribe(InterceptSubscribeMessage msg) {
+            n.set(70);
+        }
+
+        @Override
+        public void onUnsubscribe(InterceptUnsubscribeMessage msg) {
+            n.set(80);
+        }
+
+        @Override
+        public void onMessageAcknowledged(InterceptAcknowledgedMessage msg) {
+            n.set(90);
+        }
+    }
+
+    private static final BrokerInterceptor interceptor = new BrokerInterceptor(
+        Collections.<InterceptHandler>singletonList(new MockObserver()));
+
+    @BeforeClass
+    public static void beforeAllTests() {
+        // check if any of the handler methods was called before notifications
+        assertEquals(0, n.get());
+    }
+
+    @AfterClass
+    public static void afterAllTests() {
+        interceptor.stop();
+    }
+
+    /* Used to wait handler notification by the interceptor internal thread */
+    private static void interval() throws InterruptedException {
+        Thread.sleep(100);
+    }
+
+    @Test
+    public void testNotifyClientConnected() throws Exception {
+        interceptor.notifyClientConnected(MqttMessageBuilders.connect().build());
+        interval();
+        assertEquals(40, n.get());
+    }
+
+    @Test
+    public void testNotifyClientDisconnected() throws Exception {
+        interceptor.notifyClientDisconnected("cli1234", "cli1234");
+        interval();
+        assertEquals(50, n.get());
+    }
+
+    @Test
+    public void testNotifyTopicPublished() throws Exception {
+        interceptor.notifyTopicPublished(
+                MqttMessageBuilders.publish().qos(MqttQoS.AT_MOST_ONCE)
+                    .payload(Unpooled.copiedBuffer("Hello".getBytes(UTF_8))).build(),
+                "cli1234",
+                "cli1234");
+        interval();
+        assertEquals(60, n.get());
+    }
+
+    @Test
+    public void testNotifyTopicSubscribed() throws Exception {
+        interceptor.notifyTopicSubscribed(new Subscription("cli1", new Topic("o2"), MqttQoS.AT_MOST_ONCE), "cli1234");
+        interval();
+        assertEquals(70, n.get());
+    }
+
+    @Test
+    public void testNotifyTopicUnsubscribed() throws Exception {
+        interceptor.notifyTopicUnsubscribed("o2", "cli1234", "cli1234");
+        interval();
+        assertEquals(80, n.get());
+    }
+
+    @Test
+    public void testAddAndRemoveInterceptHandler() throws Exception {
+        InterceptHandler interceptHandlerMock1 = mock(InterceptHandler.class);
+        InterceptHandler interceptHandlerMock2 = mock(InterceptHandler.class);
+        // add
+        interceptor.addInterceptHandler(interceptHandlerMock1);
+        interceptor.addInterceptHandler(interceptHandlerMock2);
+
+        Subscription subscription = new Subscription("cli1", new Topic("o2"), MqttQoS.AT_MOST_ONCE);
+        interceptor.notifyTopicSubscribed(subscription, "cli1234");
+        interval();
+
+        verify(interceptHandlerMock1).onSubscribe(refEq(new InterceptSubscribeMessage(subscription, "cli1234")));
+        verify(interceptHandlerMock2).onSubscribe(refEq(new InterceptSubscribeMessage(subscription, "cli1234")));
+
+        // remove
+        interceptor.removeInterceptHandler(interceptHandlerMock1);
+
+        interceptor.notifyTopicSubscribed(subscription, "cli1235");
+        interval();
+        // removeInterceptHandler() performs another interaction
+        // TODO: fix this
+        // verifyNoMoreInteractions(interceptHandlerMock1);
+        verify(interceptHandlerMock2).onSubscribe(refEq(new InterceptSubscribeMessage(subscription, "cli1235")));
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/persistence/H2PersistentQueueTest.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/persistence/H2PersistentQueueTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package com.echostreams.pulsar.mqtt.persistence;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import org.h2.mvstore.MVStore;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+
+public class H2PersistentQueueTest {
+
+    private MVStore mvStore;
+
+    @Before
+    public void setUp() {
+        this.mvStore = new MVStore.Builder()
+                .fileName(BrokerConstants.DEFAULT_PERSISTENT_PATH)
+                .autoCommitDisabled()
+                .open();
+    }
+
+    @After
+    public void tearDown() {
+        File dbFile = new File(BrokerConstants.DEFAULT_PERSISTENT_PATH);
+        if (dbFile.exists()) {
+            dbFile.delete();
+        }
+        assertFalse(dbFile.exists());
+    }
+
+    @Test
+    public void testAdd() {
+        H2PersistentQueue<String> sut = new H2PersistentQueue<>(this.mvStore, "test");
+
+        sut.add("Hello");
+        sut.add("world");
+
+        assertEquals("Hello", sut.peek());
+        assertEquals("Hello", sut.peek());
+        assertEquals("peek just return elements, doesn't remove them", 2, sut.size());
+    }
+
+    @Test
+    public void testPoll() {
+        H2PersistentQueue<String> sut = new H2PersistentQueue<>(this.mvStore, "test");
+        sut.add("Hello");
+        sut.add("world");
+
+        assertEquals("Hello", sut.poll());
+        assertEquals("world", sut.poll());
+        assertTrue("after poll 2 elements inserted before, should be empty", sut.isEmpty());
+    }
+
+    @Ignore
+    @Test
+    public void testPerformance() {
+        H2PersistentQueue<String> sut = new H2PersistentQueue<>(this.mvStore, "test");
+
+        int numIterations = 10000000;
+        for (int i = 0; i < numIterations; i++) {
+            sut.add("Hello");
+        }
+        mvStore.commit();
+
+        for (int i = 0; i < numIterations; i++) {
+            assertEquals("Hello", sut.poll());
+        }
+
+        assertTrue("should be empty", sut.isEmpty());
+    }
+
+    @Test
+    public void testReloadFromPersistedState() {
+        H2PersistentQueue<String> before = new H2PersistentQueue<>(this.mvStore, "test");
+        before.add("Hello");
+        before.add("crazy");
+        before.add("world");
+        assertEquals("Hello", before.poll());
+        this.mvStore.commit();
+        this.mvStore.close();
+
+        this.mvStore = new MVStore.Builder()
+                .fileName(BrokerConstants.DEFAULT_PERSISTENT_PATH)
+                .autoCommitDisabled()
+                .open();
+
+        //now reload the persisted state
+        H2PersistentQueue<String> after = new H2PersistentQueue<>(this.mvStore, "test");
+
+        assertEquals("crazy", after.poll());
+        assertEquals("world", after.poll());
+        assertTrue("should be empty", after.isEmpty());
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/spec/v3_1_1/connection/ConnectionIT.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/spec/v3_1_1/connection/ConnectionIT.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.spec.v3_1_1.connection;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import com.echostreams.pulsar.mqtt.broker.Server;
+import com.echostreams.pulsar.mqtt.integration.IntegrationUtils;
+import com.echostreams.pulsar.mqtt.testclient.RawClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ConnectionIT {
+
+    Server m_server;
+
+    protected void startServer() throws IOException {
+        m_server = new Server();
+        m_server.startServer();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        startServer();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        m_server.stopServer();
+
+        File dbFile = new File(BrokerConstants.DEFAULT_PERSISTENT_PATH);
+        if (dbFile.exists()) {
+            assertTrue(
+                    "Error deleting the moquette db file " + BrokerConstants.DEFAULT_PERSISTENT_PATH,
+                    dbFile.delete());
+        }
+        assertFalse(dbFile.exists());
+        IntegrationUtils.clearTestStorage();
+    }
+
+    @Test(timeout = 3000)
+    public void testConnectThenClose() throws Exception {
+        RawClient.connect("127.0.0.1", 1883).isConnected()
+                // CONNECT
+                .write(0x10) // MQTT Control Packet type(1)
+                .write(0x13) // Remaining Length
+                .write(0x00, 0x04) // Protocol Name Length
+                .write("MQTT") // Protocol Name
+                .write(0x04) // The value of the Protocol Level field for the version 3.1.1 of the
+                             // protocol is 4 (0x04)
+
+                // Connect Flags
+                // User Name Flag(0)
+                // Password Flag(0)
+                // Will Retain(0)
+                // Will QoS(00)
+                // Will Flag(0)
+                // Clean Session(1)
+                .write(0x02) // Reserved(0)
+                .write(0x00, 0x00) // Keep Alive
+
+                // Payload
+                .write(0x00, 0x07) // Client Identifier Length
+                .write("client1") // Client Identifier
+                .flush()
+
+                // CONNACK
+                .read(0x20) // MQTT Control Packet type(2)
+                .read(0x02) // Remaining Length
+
+                // Connect Acknowledge Flags
+                .read(0x00) // Session Present Flag(0)
+
+                // Connect Return code
+                .read(0x00) // Connection Accepted
+
+                // DISCONNECT
+                .write(0xE0) // MQTT Control Packet type(14)
+                .write(0x00) // Remaining Length
+                .closed(1000);
+    }
+
+    @Test(timeout = 3000)
+    public void testConnectWithInvalidWillQoS() throws Exception {
+        RawClient.connect("127.0.0.1", 1883).isConnected()
+                // CONNECT
+                .write(0x10) // MQTT Control Packet type(1)
+                .write(0x13) // Remaining Length
+                .write(0x00, 0x04) // Protocol Name Length
+                .write("MQTT") // Protocol Name
+                .write(0x04) // The value of the Protocol Level field for the version 3.1.1 of the
+                             // protocol is 4 (0x04)
+
+                // Connect Flags
+                // User Name Flag(0)
+                // Password Flag(0)
+                // Will Retain(0)
+                // Will QoS(11) - It MUST NOT be 3 (0x03). Server should close the connection.
+                // Will Flag(1)
+                // Clean Session(1)
+                .write(0x1E) // Reserved(0)
+                .write(0x00, 0x00) // Keep Alive
+
+                // Payload
+                .write(0x00, 0x07) // Client Identifier Length
+                .write("client1") // Client Identifier
+                .flush()
+
+                .closed(1000);
+    }
+
+    @Ignore("Need to validate the test case.")
+    @Test(timeout = 15000)
+    public void testConnectWithWillFlagSetToZeroButWillQoSFlagSetToNonZero() throws Exception {
+        RawClient.connect("127.0.0.1", 1883).isConnected()
+                // CONNECT
+                .write(0x10) // MQTT Control Packet type(1)
+                .write(0x12) // Remaining Length
+                .write(0x00, 0x04) // Protocol Name Length
+                .write("MQTT") // Protocol Name
+                .write(0x04) // The value of the Protocol Level field for the version 3.1.1 of the
+                             // protocol is 4 (0x04)
+
+                // Connect Flags
+                // User Name Flag(0)
+                // Password Flag(0)
+                // Will Retain(0)
+                // Will QoS(01) - If the Will Flag is set to 0, then the Will QoS MUST be set to 0
+                // Will Flag(0)
+                // Clean Session(1)
+                .write(0x0A) // Reserved(0)
+
+                .write(0x00, 0x00) // Keep Alive
+
+                // Payload
+                .write(0x00, 0x07) // Client Identifier Length
+                .write("client1") // Client Identifier
+
+                // Server MUST close the Network Connection due to invalid Will QoS flag
+                .closed();
+    }
+
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/testclient/Client.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/testclient/Client.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.testclient;
+
+import com.echostreams.pulsar.mqtt.BrokerConstants;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.*;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.mqtt.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.Charset;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
+import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
+
+/**
+ * Class used just to send and receive MQTT messages without any protocol login in action, just use
+ * the encoder/decoder part.
+ */
+public class Client {
+
+    public interface ICallback {
+
+        void call(MqttMessage msg);
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(Client.class);
+    final ClientNettyMQTTHandler handler = new ClientNettyMQTTHandler();
+    EventLoopGroup workerGroup;
+    Channel m_channel;
+    private boolean m_connectionLost;
+    private ICallback callback;
+    private String clientId;
+    private MqttMessage receivedMsg;
+
+    public Client(String host) {
+        this(host, BrokerConstants.PORT);
+    }
+
+    @SuppressWarnings("FutureReturnValueIgnored")
+    public Client(String host, int port) {
+        handler.setClient(this);
+        workerGroup = new NioEventLoopGroup();
+        try {
+            Bootstrap b = new Bootstrap();
+            b.group(workerGroup);
+            b.channel(NioSocketChannel.class);
+            b.option(ChannelOption.SO_KEEPALIVE, true);
+            b.handler(new ChannelInitializer<SocketChannel>() {
+
+                @Override
+                public void initChannel(SocketChannel ch) throws Exception {
+                    ChannelPipeline pipeline = ch.pipeline();
+                    pipeline.addLast("decoder", new MqttDecoder());
+                    pipeline.addLast("encoder", MqttEncoder.INSTANCE);
+                    pipeline.addLast("handler", handler);
+                }
+            });
+
+            // Start the client.
+            m_channel = b.connect(host, port).sync().channel();
+        } catch (Exception ex) {
+            LOG.error("Error received in client setup", ex);
+            workerGroup.shutdownGracefully();
+        }
+    }
+
+    public Client clientId(String clientId) {
+        this.clientId = clientId;
+        return this;
+    }
+
+    public void connect(String willTestamentTopic, String willTestamentMsg) {
+        MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(
+                MqttMessageType.CONNECT,
+                false,
+                MqttQoS.AT_MOST_ONCE,
+                false,
+                0);
+        MqttConnectVariableHeader mqttConnectVariableHeader = new MqttConnectVariableHeader(
+                MqttVersion.MQTT_3_1.protocolName(),
+                MqttVersion.MQTT_3_1.protocolLevel(),
+                false,
+                false,
+                false,
+                MqttQoS.AT_MOST_ONCE.value(),
+                true,
+                true,
+                2);
+        MqttConnectPayload mqttConnectPayload = new MqttConnectPayload(
+                this.clientId,
+                willTestamentTopic,
+                willTestamentMsg.getBytes(Charset.forName("UTF-8")),
+                null,
+                null);
+        MqttConnectMessage connectMessage = new MqttConnectMessage(
+                mqttFixedHeader,
+                mqttConnectVariableHeader,
+                mqttConnectPayload);
+
+        /*
+         * ConnectMessage connectMessage = new ConnectMessage();
+         * connectMessage.setProtocolVersion((byte) 3); connectMessage.setClientID(this.clientId);
+         * connectMessage.setKeepAlive(2); //secs connectMessage.setWillFlag(true);
+         * connectMessage.setWillMessage(willTestamentMsg.getBytes());
+         * connectMessage.setWillTopic(willTestamentTopic);
+         * connectMessage.setWillQos(MqttQoS.AT_MOST_ONCE.byteValue());
+         */
+
+        doConnect(connectMessage);
+    }
+
+    public void connect() {
+        MqttConnectMessage connectMessage = MqttMessageBuilders.connect().protocolVersion(MqttVersion.MQTT_3_1_1)
+                .clientId("").keepAlive(2) // secs
+                .willFlag(false).willQoS(MqttQoS.AT_MOST_ONCE).build();
+
+        doConnect(connectMessage);
+    }
+
+    private void doConnect(MqttConnectMessage connectMessage) {
+        final CountDownLatch latch = new CountDownLatch(1);
+        this.setCallback(msg -> {
+            receivedMsg = msg;
+            latch.countDown();
+        });
+
+        this.sendMessage(connectMessage);
+
+        try {
+            latch.await(200, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Cannot receive message in 200 ms", e);
+        }
+        if (!(this.receivedMsg instanceof MqttConnAckMessage)) {
+            MqttMessageType messageType = this.receivedMsg.fixedHeader().messageType();
+            throw new RuntimeException("Expected a CONN_ACK message but received " + messageType);
+        }
+    }
+
+    public void setCallback(ICallback callback) {
+        this.callback = callback;
+    }
+
+    public void sendMessage(MqttMessage msg) {
+        m_channel.writeAndFlush(msg).addListener(FIRE_EXCEPTION_ON_FAILURE);
+    }
+
+    public MqttMessage lastReceivedMessage() {
+        return this.receivedMsg;
+    }
+
+    void messageReceived(MqttMessage msg) {
+        LOG.info("Received message {}", msg);
+        if (this.callback != null) {
+            this.callback.call(msg);
+        }
+    }
+
+    void setConnectionLost(boolean status) {
+        m_connectionLost = status;
+    }
+
+    public boolean isConnectionLost() {
+        return m_connectionLost;
+    }
+
+    @SuppressWarnings("FutureReturnValueIgnored")
+    public void close() throws InterruptedException {
+        // Wait until the connection is closed.
+        m_channel.closeFuture().sync().addListener(CLOSE_ON_FAILURE);
+        if (workerGroup == null) {
+            throw new IllegalStateException("Invoked close on an Acceptor that wasn't initialized");
+        }
+        workerGroup.shutdownGracefully();
+    }
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/testclient/ClientNettyMQTTHandler.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/testclient/ClientNettyMQTTHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.testclient;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
+
+@ChannelHandler.Sharable
+class ClientNettyMQTTHandler extends ChannelInboundHandlerAdapter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClientNettyMQTTHandler.class);
+    private Client m_client;
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object message) {
+        MqttMessage msg = (MqttMessage) message;
+        LOG.info("Received a message of type {}", msg.fixedHeader().messageType());
+        m_client.messageReceived(msg);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        m_client.setConnectionLost(true);
+        ctx.close().addListener(CLOSE_ON_FAILURE);
+    }
+
+    void setClient(Client client) {
+        m_client = client;
+    }
+
+}

--- a/src/test/java/com/echostreams/pulsar/mqtt/testclient/RawClient.java
+++ b/src/test/java/com/echostreams/pulsar/mqtt/testclient/RawClient.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package com.echostreams.pulsar.mqtt.testclient;
+
+import com.echostreams.pulsar.mqtt.Utils;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.*;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.ReferenceCountUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
+
+/**
+ * This class is used to have a fluent interface to interact with a integration. Inspired by
+ * org.kaazing.robot
+ */
+public final class RawClient {
+
+    @ChannelHandler.Sharable
+    class RawMessageHandler extends ChannelInboundHandlerAdapter {
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object message) {
+            LOG.info("Received a message {}", message);
+            try {
+                ByteBuf in = (ByteBuf) message;
+                int readBytes = in.readableBytes();
+                heapBuffer.writeBytes(in);
+                readableBytesSem.release(readBytes);
+            } finally {
+                ReferenceCountUtil.release(message);
+            }
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) {
+            disconnectLatch.countDown();
+            ctx.close().addListener(CLOSE_ON_FAILURE);
+        }
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(RawClient.class);
+    final RawMessageHandler handler;
+    EventLoopGroup workerGroup;
+    Channel m_channel;
+
+    private boolean connected;
+    private ByteBuf heapBuffer;
+    private CountDownLatch disconnectLatch;
+    private final Semaphore readableBytesSem;
+
+    @SuppressWarnings("FutureReturnValueIgnored")
+    private RawClient(String host, int port) {
+        handler = new RawMessageHandler();
+        heapBuffer = Unpooled.buffer(128);
+        disconnectLatch = new CountDownLatch(1);
+        readableBytesSem = new Semaphore(0, true);
+
+        workerGroup = new NioEventLoopGroup();
+
+        try {
+            Bootstrap b = new Bootstrap();
+            b.group(workerGroup);
+            b.channel(NioSocketChannel.class);
+            b.option(ChannelOption.SO_KEEPALIVE, true);
+            b.handler(new ChannelInitializer<SocketChannel>() {
+
+                @Override
+                public void initChannel(SocketChannel ch) throws Exception {
+                    ChannelPipeline pipeline = ch.pipeline();
+                    pipeline.addLast("handler", handler);
+                }
+            });
+
+            // Start the client.
+            m_channel = b.connect(host, port).sync().channel();
+            this.connected = true;
+        } catch (Exception ex) {
+            LOG.error("Error received in client setup", ex);
+            workerGroup.shutdownGracefully();
+        }
+    }
+
+    public static RawClient connect(String host, int port) {
+        return new RawClient(host, port);
+    }
+
+    public RawClient isConnected() {
+        if (!this.connected) {
+            throw new IllegalStateException("Can't connect the client");
+        }
+        return this;
+    }
+
+    public RawClient write(int... bytes) {
+        ByteBuf buff = Unpooled.buffer(bytes.length);
+        buff.clear();
+        for (int b : bytes) {
+            buff.writeByte((byte) b);
+        }
+        m_channel.write(buff).addListener(CLOSE_ON_FAILURE);
+        return this;
+    }
+
+    public RawClient writeWithSize(String str) {
+        ByteBuf buff = Unpooled.buffer(str.length() + 2);
+        buff.writeBytes(Utils.encodeString(str));
+        m_channel.write(buff).addListener(CLOSE_ON_FAILURE);
+        return this;
+    }
+
+    /**
+     * Write just String bytes not length
+     */
+    public RawClient write(String str) {
+        ByteBuf out = Unpooled.buffer(str.length());
+        byte[] raw;
+        try {
+            raw = str.getBytes("UTF-8");
+            // NB every Java platform has got UTF-8 encoding by default, so this
+            // exception are never raised.
+        } catch (UnsupportedEncodingException ex) {
+            throw new IllegalStateException(ex);
+        }
+        out.writeBytes(raw);
+        m_channel.write(out).addListener(CLOSE_ON_FAILURE);
+        return this;
+    }
+
+    public RawClient flush() {
+        m_channel.flush();
+        return this;
+    }
+
+    public RawClient read(int expectedByte) {
+        try {
+            readableBytesSem.acquire(1);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("Interrupted while waiting data");
+        }
+        byte b = heapBuffer.readByte();
+        if (b != expectedByte) {
+            throw new IllegalStateException(String.format("Expected byte 0x%02X but found 0x%02X", b, expectedByte));
+        }
+        return this;
+    }
+
+    /**
+     * Expect the closing of the underling channel, with timeout
+     */
+    public void closed(long timeout) throws InterruptedException {
+        disconnectLatch.await(timeout, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Expect closing the connect with unbound time
+     */
+    public void closed() throws InterruptedException {
+        disconnectLatch.await();
+    }
+}


### PR DESCRIPTION
*Initial moquette broker imlementation. 
*Migrated to maven project and fixed missing pom dependencies.
*Added assembly pluging to create executable build. 
*Added configurable property in config file for 1. mqtt traffic : unencrytped, encrypted or both is 
    configurable and will be working by enabling and disabling port. 2. Server ports are also configurable. 
    3.The Puslar persistence, tenant and namespace defaults made configurable.
*Added code to read default config value from application.properties updated to broker constants. *Validation to only allow persistent/non-persistent as message storage type prefix for topic.
*Added code to send mqtt message to pulsar broker once it received to mqtt broker. 
*Added configurable regular expression and match against topic upon unmatch drop the message. *Added  code to map with default pulsar prefix defined in config file when topic is not mapped with persistent/tenant/namespace. 
*Added startApp script to run on windows and ubuntu